### PR TITLE
revert back to old network id

### DIFF
--- a/networks/arcadia.json
+++ b/networks/arcadia.json
@@ -1,6 +1,6 @@
 {
   "name": "Arcadia Nodle Network",
-  "id": "nodle_arcadia",
+  "id": "arcadia",
   "bootNodes": [
     "/ip4/35.200.78.9/tcp/30333/p2p/QmWZ3CfMuZ8U15SWoGSnRZ1cpzDsVHqmuvi4ThCB5zQVGg",
     "/ip4/34.73.134.186/tcp/30333/p2p/QmZcst3MYHxJXoW5RgHnLrfz1ZZB9C7KgaJ6P69pABRJav"


### PR DESCRIPTION
# Fix network id
#23 included by mistake a commit that changed the network id in our chainspec,
go back.
