### PR TITLE
spec version bump

### DIFF
--- a/networks/arcadia.json
+++ b/networks/arcadia.json
@@ -1,6 +1,6 @@
 {
   "name": "Arcadia Nodle Network",
-  "id": "nodle_arcadia",
+  "id": "arcadia",
   "bootNodes": [
     "/ip4/35.200.78.9/tcp/30333/p2p/QmWZ3CfMuZ8U15SWoGSnRZ1cpzDsVHqmuvi4ThCB5zQVGg",
     "/ip4/34.73.134.186/tcp/30333/p2p/QmZcst3MYHxJXoW5RgHnLrfz1ZZB9C7KgaJ6P69pABRJav"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -104,8 +104,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("nodle-chain"),
     impl_name: create_runtime_str!("nodle-chain"),
     authoring_version: 1,
-    spec_version: 5,
-    impl_version: 2,
+    spec_version: 6,
+    impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
 };
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -100,12 +100,31 @@ pub mod opaque {
 }
 
 /// This runtime version.
+/// This should not be thought of as classic Semver (major/minor/tiny).
+/// This triplet have different semantics and mis-interpretation could cause problems.
+/// In particular: bug fixes should result in an increment of `spec_version` and possibly `authoring_version`,
+/// absolutely not `impl_version` since they change the semantics of the runtime.
 pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("nodle-chain"),
     impl_name: create_runtime_str!("nodle-chain"),
+
+    /// `authoring_version` is the version of the authorship interface. An authoring node
+    /// will not attempt to author blocks unless this is equal to its native runtime.
     authoring_version: 1,
+
+    /// Version of the runtime specification. A full-node will not attempt to use its native
+    /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
+    /// `spec_version` and `authoring_version` are the same between Wasm and native.
     spec_version: 6,
+
+    /// Version of the implementation of the specification. Nodes are free to ignore this; it
+    /// serves only as an indication that the code is different; as long as the other two versions
+    /// are the same then while the actual code may be different, it is nonetheless required to
+    /// do the same thing.
+    /// Non-consensus-breaking optimizations are about the only changes that could be made which
+    /// would result in only the `impl_version` changing.
     impl_version: 0,
+
     apis: RUNTIME_API_VERSIONS,
 };
 


### PR DESCRIPTION
# Bump `spec_version` in runtime
Thanks to the precious help received at paritytech/subport#2 we
discovered that we need to bump `spec_version` in order to avoid
the panic reported in #21.

Fixes #21.

## Quality
- [x] I have added comments and documentation

## Testing
- [x] The node runs fine on a development network
- [x] The node runs fine on a local network
- [x] The node runs fine on an upgraded local network
- [x] The node can synchronize the existing network
- [x] Runtime upgrade deployed
