### PR TITLE
add trailing slash

### DIFF
--- a/.maintain/docker/Dockerfile
+++ b/.maintain/docker/Dockerfile
@@ -23,7 +23,7 @@ COPY --from=builder /nodle-chain/target/$PROFILE/nodle-chain /usr/local/bin
 
 COPY ./.maintain/docker/entrypoint.sh .
 COPY ./.maintain/docker/load_keys.sh .
-COPY ./networks/* .
+COPY ./networks/* ./
 
 RUN apt-get update && \
 	apt-get upgrade -y && \


### PR DESCRIPTION
# Fix docker configuration
Quite some changes were introduced in #33, however this broke the docker container
when trying to add the chain spec files to it. This PR fixes it.
