### PR TITLE
make frame-benchmarking-cli non optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ version = '2.0.0-alpha.6'
 [dependencies.frame-benchmarking-cli]
 default-features = false
 version = '2.0.0-alpha.6'
-optional = true
 
 [dependencies.futures01]
 package = 'futures'
@@ -135,7 +134,7 @@ members = [
 [features]
 runtime-benchmarks = [
 	"nodle-chain-runtime/runtime-benchmarks",
-	"frame-benchmarking-cli",
+	#"frame-benchmarking-cli",
 ]
 
 


### PR DESCRIPTION
# Compile with benchmarks
`frame-benchmarking-cli` was marked as `optional` which prevented the
compiling of the node without the benchmark options.
