### PR TITLE
reserve apply_as

### DIFF
--- a/pallets/reserve/src/tests.rs
+++ b/pallets/reserve/src/tests.rs
@@ -32,6 +32,7 @@ use sp_runtime::{
     DispatchError::BadOrigin,
     Perbill,
 };
+use sp_std::prelude::Box;
 
 impl_outer_origin! {
     pub enum Origin for Test {}
@@ -133,5 +134,29 @@ fn tip() {
         assert_ok!(TestModule::tip(Origin::signed(999), 50));
         assert_eq!(Balances::free_balance(999), 50);
         assert_eq!(Balances::free_balance(TestModule::account_id()), 50);
+    })
+}
+
+fn make_call(value: u8) -> Box<frame_system::Call<Test>> {
+    Box::new(frame_system::Call::<Test>::remark(vec![value]))
+}
+
+#[test]
+fn apply_as_error_if_bad_origin() {
+    new_test_ext().execute_with(|| {
+        assert_noop!(
+            TestModule::apply_as(Origin::signed(0), make_call(1)),
+            BadOrigin
+        );
+    })
+}
+
+#[test]
+fn apply_as_works() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(TestModule::apply_as(
+            Origin::signed(Admin::get()),
+            make_call(1)
+        ));
     })
 }

--- a/pallets/reserve/src/tests.rs
+++ b/pallets/reserve/src/tests.rs
@@ -84,6 +84,7 @@ impl Trait for Test {
     type Event = ();
     type Currency = balances::Module<Self>;
     type ExternalOrigin = EnsureSignedBy<Admin, u64>;
+    type Call = frame_system::Call<Test>;
 }
 type TestModule = Module<Test>;
 type Balances = balances::Module<Test>;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -134,7 +134,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native
     /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     /// `spec_version` and `authoring_version` are the same between Wasm and native.
-    spec_version: 8,
+    spec_version: 9,
 
     /// Version of the implementation of the specification. Nodes are free to ignore this; it
     /// serves only as an indication that the code is different; as long as the other two versions
@@ -437,6 +437,7 @@ impl reserve::Trait for Runtime {
     type Currency = balances::Module<Runtime>;
     type ExternalOrigin =
         collective::EnsureProportionMoreThan<_1, _2, AccountId, TechnicalCollective>;
+    type Call = Call;
 }
 
 parameter_types! {


### PR DESCRIPTION
## Add `apply_as` extrinsic to `pallet-reserve`
`apply_as` will be useful when trying to send transaction coming **from** the company reserve (for instance, creating vested grants).

Fixes #31.

> No need to push an upgrade for this, we will bundle changes into a network wide upgrade later.

### Quality
- [x] I have added unit tests
- [x] All unit tests are passing
- [x] I have added comments and documentation

### Testing
- [x] I have tested my changes on a local network
- [x] I have tested my changes on a local upgraded network
