### PR TITLE
try origin or root

### DIFF
--- a/pallets/reserve/src/tests.rs
+++ b/pallets/reserve/src/tests.rs
@@ -160,3 +160,15 @@ fn apply_as_works() {
         ));
     })
 }
+
+#[test]
+fn try_root_if_not_admin() {
+    new_test_ext().execute_with(|| {
+        let mut total_imbalance = <PositiveImbalanceOf<Test>>::zero();
+        let r = <Test as Trait>::Currency::deposit_creating(&TestModule::account_id(), 100);
+        total_imbalance.subsume(r);
+
+        assert_ok!(TestModule::spend(Origin::ROOT, 3, 100));
+        assert_ok!(TestModule::apply_as(Origin::ROOT, make_call(1)));
+    })
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -135,7 +135,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native
     /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     /// `spec_version` and `authoring_version` are the same between Wasm and native.
-    spec_version: 11,
+    spec_version: 12,
 
     /// Version of the implementation of the specification. Nodes are free to ignore this; it
     /// serves only as an indication that the code is different; as long as the other two versions


### PR DESCRIPTION
# Use `try_origin` and fallback to `try_root`
In order to support a more robust governance model, copy parity's pattern and let root override `EnsureOrigin` calls.

Fixes #56.

## Sanity
- [x] I have incremented the runtime version number

## Quality
- [x] I have added unit tests
- [x] All unit tests are passing
- [ ] I have added comments and documentation

## Testing
- [ ] I have tested my changes on a local network
- [ ] I have tested my changes on a local upgraded network
