### PR TITLE
emergency shutdown

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/runtime_or_pallets.md
+++ b/.github/PULL_REQUEST_TEMPLATE/runtime_or_pallets.md
@@ -8,9 +8,14 @@ Fixes [if needed, mention the issues involved].
 
 ### Quality
 - [ ] I have added unit tests
+- [ ] I have added benchmarks to my pallet
+- [ ] I have added the benchmarks to the node
 - [ ] All unit tests are passing
 - [ ] I have added comments and documentation
 
 ### Testing
 - [ ] I have tested my changes on a local network
 - [ ] I have tested my changes on a local upgraded network
+
+### Network operations
+- [ ] I have incremented the appropriate version numbers in the runtime

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,6 +3246,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-emergency-shutdown"
+version = "2.0.0-alpha.6"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2960,6 +2960,7 @@ dependencies = [
  "pallet-babe",
  "pallet-balances",
  "pallet-collective",
+ "pallet-emergency-shutdown",
  "pallet-grandpa",
  "pallet-identity",
  "pallet-im-online",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3257,6 +3257,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
 	'node',
+	'pallets/emergency-shutdown',
 	'pallets/poa',
 	'pallets/reserve',
 	'runtime'

--- a/pallets/emergency-shutdown/Cargo.toml
+++ b/pallets/emergency-shutdown/Cargo.toml
@@ -13,7 +13,7 @@ std = [
     "serde",
     "sp-io/std",
     "sp-runtime/std",
-    #"sp-std/std",
+    "sp-std/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking",
@@ -29,7 +29,7 @@ parity-scale-codec = { version = "1.2.0", default-features = false, features = [
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 sp-io = { version = "2.0.0-alpha.6", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
-#sp-std = { version = "2.0.0-alpha.6", default-features = false }
+sp-std = { version = "2.0.0-alpha.6", default-features = false }
 
 
 [dev-dependencies]

--- a/pallets/emergency-shutdown/Cargo.toml
+++ b/pallets/emergency-shutdown/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "pallet-emergency-shutdown"
+version = "2.0.0-alpha.6"
+authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
+edition = "2018"
+
+[features]
+default = ["std"]
+std = [
+    "frame-support/std",
+    "frame-system/std",
+    "parity-scale-codec/std",
+    "serde",
+    "sp-io/std",
+    "sp-runtime/std",
+    #"sp-std/std",
+]
+runtime-benchmarks = [
+	"frame-benchmarking",
+    "frame-system/runtime-benchmarks",
+	"frame-support/runtime-benchmarks",
+]
+
+[dependencies]
+frame-benchmarking = { version = "2.0.0-alpha.6", default-features = false, optional = true }
+frame-support = { version = "2.0.0-alpha.6", default-features = false }
+frame-system = { version = "2.0.0-alpha.6", default-features = false }
+parity-scale-codec = { version = "1.2.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.101", optional = true, features = ["derive"] }
+sp-io = { version = "2.0.0-alpha.6", default-features = false }
+sp-runtime = { version = "2.0.0-alpha.6", default-features = false }
+#sp-std = { version = "2.0.0-alpha.6", default-features = false }
+
+
+[dev-dependencies]
+sp-core = { version = "2.0.0-alpha.6", default-features = false }

--- a/pallets/emergency-shutdown/src/benchmarking.rs
+++ b/pallets/emergency-shutdown/src/benchmarking.rs
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the Nodle Chain distributed at https://github.com/NodleCode/chain
+ * Copyright (C) 2020  Nodle International
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//! Reserve pallet benchmarks
+
+#![cfg(feature = "runtime-benchmarks")]
+
+use super::*;
+
+use frame_benchmarking::{account, benchmarks};
+use frame_system::RawOrigin;
+use sp_runtime::traits::{Dispatchable, Saturating};
+
+const SEED: u32 = 0;
+
+benchmarks! {
+    _ { }
+
+    toggle {
+        let u in 0 .. 1000;
+
+        let call = Call::<T>::toggle();
+        let origin = T::ShutdownOrigin::successful_origin();
+    }: {
+        let _ = call.dispatch(origin)?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::{new_test_ext, Test};
+    use frame_support::assert_ok;
+
+    #[test]
+    fn test_benchmarks() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_toggle::<Test>());
+        });
+    }
+}

--- a/pallets/emergency-shutdown/src/lib.rs
+++ b/pallets/emergency-shutdown/src/lib.rs
@@ -1,0 +1,72 @@
+/*
+ * This file is part of the Nodle Chain distributed at https://github.com/NodleCode/chain
+ * Copyright (C) 2020  Nodle International
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//! Handle the ability to notify other pallets that they should stop all
+//! operations, or resume them
+
+mod benchmarking;
+
+#[cfg(test)]
+mod tests;
+
+use frame_support::{
+    decl_event, decl_module, decl_storage, dispatch::DispatchResult, traits::EnsureOrigin,
+    weights::SimpleDispatchInfo,
+};
+use frame_system::{self as system, ensure_root};
+
+/// The module's configuration trait.
+pub trait Trait: frame_system::Trait {
+    type Event: From<Event> + Into<<Self as frame_system::Trait>::Event>;
+    type ShutdownOrigin: EnsureOrigin<Self::Origin>;
+}
+
+decl_storage! {
+    trait Store for Module<T: Trait> as EmergencyShutdown {
+        pub Shutdown get(fn shutdown): bool;
+    }
+}
+
+decl_module! {
+    /// The module declaration.
+    pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+        fn deposit_event() = default;
+
+        /// Toggle the shutdown state if authorized to do so.
+        #[weight = SimpleDispatchInfo::FixedOperational(10_000)]
+        pub fn toggle_shutdown(origin) -> DispatchResult {
+            T::ShutdownOrigin::try_origin(origin)
+                .map(|_| ())
+                .or_else(ensure_root)?;
+
+            Shutdown::put(!Self::shutdown());
+            Self::deposit_event(Event::ShutdownToggled(Self::shutdown()));
+
+            Ok(())
+        }
+    }
+}
+
+decl_event!(
+    pub enum Event {
+        /// Shutdown state was toggled, to either on or off.
+        ShutdownToggled(bool),
+    }
+);

--- a/pallets/emergency-shutdown/src/lib.rs
+++ b/pallets/emergency-shutdown/src/lib.rs
@@ -51,7 +51,7 @@ decl_module! {
 
         /// Toggle the shutdown state if authorized to do so.
         #[weight = SimpleDispatchInfo::FixedOperational(10_000)]
-        pub fn toggle_shutdown(origin) -> DispatchResult {
+        pub fn toggle(origin) -> DispatchResult {
             T::ShutdownOrigin::try_origin(origin)
                 .map(|_| ())
                 .or_else(ensure_root)?;

--- a/pallets/emergency-shutdown/src/tests.rs
+++ b/pallets/emergency-shutdown/src/tests.rs
@@ -91,14 +91,14 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 #[test]
 fn root_toggle() {
     new_test_ext().execute_with(|| {
-        assert_ok!(TestModule::toggle_shutdown(Origin::ROOT));
+        assert_ok!(TestModule::toggle(Origin::ROOT));
     })
 }
 
 #[test]
 fn shutdown_origin_toggle() {
     new_test_ext().execute_with(|| {
-        assert_ok!(TestModule::toggle_shutdown(Origin::signed(Admin::get())));
+        assert_ok!(TestModule::toggle(Origin::signed(Admin::get())));
     })
 }
 
@@ -107,10 +107,10 @@ fn toggle_on_off() {
     new_test_ext().execute_with(|| {
         assert_eq!(TestModule::shutdown(), false);
 
-        assert_ok!(TestModule::toggle_shutdown(Origin::ROOT));
+        assert_ok!(TestModule::toggle(Origin::ROOT));
         assert_eq!(TestModule::shutdown(), true);
 
-        assert_ok!(TestModule::toggle_shutdown(Origin::ROOT));
+        assert_ok!(TestModule::toggle(Origin::ROOT));
         assert_eq!(TestModule::shutdown(), false);
     })
 }
@@ -118,6 +118,6 @@ fn toggle_on_off() {
 #[test]
 fn non_origin_fails() {
     new_test_ext().execute_with(|| {
-        assert_noop!(TestModule::toggle_shutdown(Origin::signed(0)), BadOrigin);
+        assert_noop!(TestModule::toggle(Origin::signed(0)), BadOrigin);
     })
 }

--- a/pallets/emergency-shutdown/src/tests.rs
+++ b/pallets/emergency-shutdown/src/tests.rs
@@ -1,0 +1,123 @@
+/*
+ * This file is part of the Nodle Chain distributed at https://github.com/NodleCode/chain
+ * Copyright (C) 2020  Nodle International
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#![cfg(test)]
+
+use super::*;
+
+use frame_support::{
+    assert_noop, assert_ok, impl_outer_origin, ord_parameter_types, parameter_types,
+    weights::Weight,
+};
+use frame_system::EnsureSignedBy;
+use sp_core::H256;
+use sp_runtime::{
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
+    DispatchError::BadOrigin,
+    Perbill,
+};
+
+impl_outer_origin! {
+    pub enum Origin for Test {}
+}
+
+// For testing the module, we construct most of a mock runtime. This means
+// first constructing a configuration type (`Test`) which `impl`s each of the
+// configuration traits of modules we want to use.
+#[derive(Clone, Eq, PartialEq)]
+pub struct Test;
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+    pub const MaximumBlockWeight: Weight = 1024;
+    pub const MaximumBlockLength: u32 = 2 * 1024;
+    pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+}
+impl frame_system::Trait for Test {
+    type Origin = Origin;
+    type Call = ();
+    type Index = u64;
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = u64;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = ();
+    type BlockHashCount = BlockHashCount;
+    type MaximumBlockWeight = MaximumBlockWeight;
+    type MaximumBlockLength = MaximumBlockLength;
+    type AvailableBlockRatio = AvailableBlockRatio;
+    type Version = ();
+    type ModuleToIndex = ();
+    type AccountData = ();
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+}
+
+ord_parameter_types! {
+    pub const Admin: u64 = 1;
+}
+impl Trait for Test {
+    type Event = ();
+    type ShutdownOrigin = EnsureSignedBy<Admin, u64>;
+}
+type TestModule = Module<Test>;
+
+// This function basically just builds a genesis storage key/value store according to
+// our desired mockup.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+    frame_system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap()
+        .into()
+}
+
+#[test]
+fn root_toggle() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(TestModule::toggle_shutdown(Origin::ROOT));
+    })
+}
+
+#[test]
+fn shutdown_origin_toggle() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(TestModule::toggle_shutdown(Origin::signed(Admin::get())));
+    })
+}
+
+#[test]
+fn toggle_on_off() {
+    new_test_ext().execute_with(|| {
+        assert_eq!(TestModule::shutdown(), false);
+
+        assert_ok!(TestModule::toggle_shutdown(Origin::ROOT));
+        assert_eq!(TestModule::shutdown(), true);
+
+        assert_ok!(TestModule::toggle_shutdown(Origin::ROOT));
+        assert_eq!(TestModule::shutdown(), false);
+    })
+}
+
+#[test]
+fn non_origin_fails() {
+    new_test_ext().execute_with(|| {
+        assert_noop!(TestModule::toggle_shutdown(Origin::signed(0)), BadOrigin);
+    })
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -16,6 +16,7 @@ std = [
     "pallet-babe/std",
     "pallet-balances/std",
     "pallet-collective/std",
+    "pallet-emergency-shutdown/std",
     "pallet-grandpa/std",
     "pallet-identity/std",
     "pallet-im-online/std",
@@ -56,6 +57,7 @@ runtime-benchmarks = [
     "frame-system/runtime-benchmarks",
     "pallet-balances/runtime-benchmarks",
     "pallet-collective/runtime-benchmarks",
+    "pallet-emergency-shutdown/runtime-benchmarks",
     "pallet-im-online/runtime-benchmarks",
     "pallet-reserve/runtime-benchmarks",
     "pallet-identity/runtime-benchmarks",
@@ -76,6 +78,7 @@ pallet-authorship = { version = "2.0.0-alpha.6", default-features = false }
 pallet-babe = { version = "2.0.0-alpha.6", default-features = false }
 pallet-balances = { version = "2.0.0-alpha.6", default-features = false }
 pallet-collective = { version = "2.0.0-alpha.6", default-features = false }
+pallet-emergency-shutdown = { version = "2.0.0-alpha.6", default-features = false, path = "../pallets/emergency-shutdown" }
 pallet-grandpa = { version = "2.0.0-alpha.6", default-features = false }
 pallet-identity = { version = "2.0.0-alpha.6", default-features = false }
 pallet-im-online = { version = "2.0.0-alpha.6", default-features = false }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -135,7 +135,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native
     /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     /// `spec_version` and `authoring_version` are the same between Wasm and native.
-    spec_version: 12,
+    spec_version: 13,
 
     /// Version of the implementation of the specification. Nodes are free to ignore this; it
     /// serves only as an indication that the code is different; as long as the other two versions
@@ -507,6 +507,12 @@ impl pallet_utility::Trait for Runtime {
     type MaxSignatories = MaxSignatories;
 }
 
+impl pallet_emergency_shutdown::Trait for Runtime {
+    type Event = Event;
+    type ShutdownOrigin =
+        pallet_collective::EnsureProportionMoreThan<_1, _2, AccountId, TechnicalCollective>;
+}
+
 construct_runtime!(
     pub enum Runtime where
         Block = Block,
@@ -543,6 +549,9 @@ construct_runtime!(
         Identity: pallet_identity::{Module, Call, Storage, Event<T>},
         Recovery: pallet_recovery::{Module, Call, Storage, Event<T>},
         Utility: pallet_utility::{Module, Call, Storage, Event<T>},
+
+        // Tokeneconomics
+        EmergencyShutdown: pallet_emergency_shutdown::{Module, Call, Storage, Event},
     }
 );
 
@@ -727,6 +736,7 @@ sp_api::impl_runtime_apis! {
             add_benchmark!(params, batches, b"identity", Identity);
 
             add_benchmark!(params, batches, b"reserve", CompanyReserve);
+            add_benchmark!(params, batches, b"emergency-shutdown", EmergencyShutdown);
 
             if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
             Ok(batches)


### PR DESCRIPTION
## Pallet for use in case of emergency shutdowns
This pallet exposes a function to `toggle` the `shutdown` state, other pallets can check this value and decide on wether they should approve a transaction or not.

Fixes #55.

### Quality
- [x] I have added unit tests
- [x] I have added benchmarks to my pallet
- [x] I have added the benchmarks to the node
- [x] All unit tests are passing
- [x] I have added comments and documentation

### Testing
- [x] I have tested my changes on a local network
- [ ] I have tested my changes on a local upgraded network

### Network operations
- [x] I have incremented the appropriate version numbers in the runtime
