### PR TITLE
handle transaction_version changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,7 @@ Describe what is changed and your reasoning.
 
 ### Sanity
 - [ ] I have incremented the runtime version number
+- [ ] I have incremented the `transaction_version` number if needed
 
 ### Quality
 - [ ] I have added unit tests, and they are passing

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -179,8 +179,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// would result in only the `impl_version` changing.
     impl_version: 0,
 
+    /// Typically this is modified when `SignedExtra` is changed.
+    transaction_version: 2,
+
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 1,
 };
 
 /// The version infromation used to identify this runtime when compiled natively.


### PR DESCRIPTION
## Context
As the name says, `transaction_version` should have been upgraded. Take the required steps to remember this.

### Sanity
- [ ] I have incremented the runtime version number
- [x] I have incremented the `transaction_version` number if needed

### Quality
- [ ] I have added unit tests, and they are passing
- [ ] I have added benchmarks to my pallet
- [ ] I have added the benchmarks to the node
- [ ] I have added comments and documentation

### Testing
- [ ] The node runs fine on a development network
- [ ] The node runs fine on a local network
- [ ] The node runs fine on an upgraded local network
- [ ] The node can synchronize the existing network
