### PR TITLE
june tuning

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -169,7 +169,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native
     /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     /// `spec_version` and `authoring_version` are the same between Wasm and native.
-    spec_version: 30,
+    spec_version: 31,
 
     /// Version of the implementation of the specification. Nodes are free to ignore this; it
     /// serves only as an indication that the code is different; as long as the other two versions

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -371,8 +371,7 @@ impl pallet_indices::Trait for Runtime {
 }
 
 parameter_types! {
-    pub const ExistentialDeposit: Balance = 100 * constants::CENTS;
-    pub const CreationFee: Balance = 1 * constants::CENTS;
+    pub const ExistentialDeposit: Balance = 1 * constants::MILLICENTS;
 }
 
 type NegativeImbalance = <Balances as Currency<AccountId>>::NegativeImbalance;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -169,7 +169,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native
     /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     /// `spec_version` and `authoring_version` are the same between Wasm and native.
-    spec_version: 31,
+    spec_version: 32,
 
     /// Version of the implementation of the specification. Nodes are free to ignore this; it
     /// serves only as an indication that the code is different; as long as the other two versions
@@ -758,6 +758,7 @@ impl pallet_allocations::Trait for Runtime {
     type ProtocolFee = ProtocolFee;
     type ProtocolFeeReceiver = CompanyReserve;
     type MaximumCoinsEverAllocated = MaximumCoinsEverAllocated;
+    type ExistentialDeposit = <Runtime as pallet_balances::Trait>::ExistentialDeposit;
 }
 
 impl pallet_membership::Trait<pallet_membership::Instance5> for Runtime {


### PR DESCRIPTION
## Context
Some tuning for our june upgrade. Also apply learning from our launch.

> Fixes [if needed, mention the issues involved].

### Sanity
- [x] I have incremented the runtime version number
- [ ] I have incremented `transaction_version` if needed

### Quality
- [ ] I have added unit tests, and they are passing
- [ ] I have added benchmarks to my pallet
- [ ] I have added the benchmarks to the node
- [ ] I have added potential RPC calls to the node
- [ ] I have eventual custom types to the `types.json` file
- [ ] I have added comments and documentation

### Testing
- [ ] The node runs fine on a development network
- [ ] The node runs fine on a local network
- [ ] The node runs fine on an upgraded local network
- [ ] The node can synchronize the existing network
