### PR TITLE
docker-compose for local network

### DIFF
--- a/.maintain/chaos/docker-compose.yml
+++ b/.maintain/chaos/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.8"
+services:
+    alice:
+        image: docker.pkg.github.com/nodlecode/chain/nodle-chain:august-2020.rc1
+        volumes:
+            - alice:/data
+        command: --chain local --alice --ws-external --rpc-cors all
+        ports:
+            - "9944:9944"
+    bob:
+        image: docker.pkg.github.com/nodlecode/chain/nodle-chain:august-2020.rc1
+        volumes:
+            - bob:/data
+        command: --chain local --bob    
+volumes:
+    alice: {}
+    bob: {}


### PR DESCRIPTION
## Context
Create a "chaos" config that can be used to play a local network in docker containers and play around with it.

> Fixes #252.

### Sanity
- [ ] I have incremented the runtime version number
- [ ] I have incremented `transaction_version` if needed

### Quality
- [ ] I have added unit tests, and they are passing
- [ ] I have added benchmarks to my pallet
- [ ] I have added the benchmarks to the node
- [ ] I have added potential RPC calls to the node
- [ ] I have eventual custom types to the `types.json` file
- [ ] I have added comments and documentation

### Testing
- [ ] The node runs fine on a development network
- [ ] The node runs fine on a local network
- [ ] The node runs fine on an upgraded local network
- [ ] The node can synchronize the existing network
