### PR TITLE
fix upgrade to rc6

### DIFF
--- a/.maintain/chaos/docker-compose.yml
+++ b/.maintain/chaos/docker-compose.yml
@@ -1,14 +1,14 @@
 version: "3.8"
 services:
     alice:
-        image: docker.pkg.github.com/nodlecode/chain/nodle-chain:august-2020.rc1
+        image: docker.pkg.github.com/nodlecode/chain/nodle-chain:may-2020
         volumes:
             - alice:/data
         command: --chain local --alice --ws-external --rpc-cors all
         ports:
             - "9944:9944"
     bob:
-        image: docker.pkg.github.com/nodlecode/chain/nodle-chain:august-2020.rc1
+        image: docker.pkg.github.com/nodlecode/chain/nodle-chain:may-2020
         volumes:
             - bob:/data
         command: --chain local --bob    

--- a/runtime/src/implementations.rs
+++ b/runtime/src/implementations.rs
@@ -45,8 +45,8 @@ impl OnUnbalanced<NegativeImbalance> for DealWithFees {
             // for fees, 20% to treasury, 80% to author
             let mut split = fees.ration(20, 80);
             if let Some(tips) = fees_then_tips.next() {
-                // for tips, if any, 80% to treasury, 20% to author (though this can be anything)
-                tips.ration_merge_into(80, 20, &mut split);
+                // for tips, if any, 20% to treasury, 80% to author (though this can be anything)
+                tips.ration_merge_into(20, 80, &mut split);
             }
             CompanyReserve::on_unbalanced(split.0);
             Author::on_unbalanced(split.1);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -96,7 +96,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native
     /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     /// `spec_version` and `authoring_version` are the same between Wasm and native.
-    spec_version: 39,
+    spec_version: 40,
 
     /// Version of the implementation of the specification. Nodes are free to ignore this; it
     /// serves only as an indication that the code is different; as long as the other two versions

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -747,6 +747,82 @@ impl pallet_membership::Trait<pallet_membership::Instance5> for Runtime {
     type MembershipChanged = Allocations;
 }
 
+use parity_scale_codec::Decode;
+use sp_runtime::RuntimeDebug;
+// Used for migration purposes, unfortunately it isn't public in the transaction_payment
+// pallet and we have to recreate it here.
+/// Storage releases of the module.
+#[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, RuntimeDebug)]
+enum Releases {
+    /// Original version of the module.
+    V1,
+    /// One that bumps the usage to FixedU128 from FixedI128.
+    V2,
+}
+
+pub struct CustomRuntimeUpgradesRc2ToRc6;
+impl CustomRuntimeUpgradesRc2ToRc6 {
+    fn transaction_payment_rename_and_convert_multiplier() -> frame_support::weights::Weight {
+        // Removed in https://github.com/paritytech/substrate/commit/cf7432a5ebef122ab685e0b9256a15c722661116
+
+        use frame_support::{
+            debug::native::error,
+            migration::{put_storage_value, take_storage_value},
+        };
+        use sp_std::convert::TryInto;
+
+        sp_runtime::print("🕊️  Migrating Transaction Payment...");
+
+        type OldMultiplier = sp_runtime::FixedI128;
+        type OldInner = <OldMultiplier as FixedPointNumber>::Inner;
+        type Inner = <Multiplier as FixedPointNumber>::Inner;
+
+        put_storage_value(b"TransactionPayment", b"StorageVersion", &[], Releases::V2);
+
+        if let Some(old) =
+            take_storage_value::<OldMultiplier>(b"TransactionPayment", b"NextFeeMultiplier", &[])
+        {
+            let inner = old.into_inner();
+            let new_inner = <OldInner as TryInto<Inner>>::try_into(inner).unwrap_or_default();
+            let new = Multiplier::from_inner(new_inner);
+            put_storage_value(b"TransactionPayment", b"NextFeeMultiplier", &[], new);
+            sp_runtime::print("🕊️  Done Transaction Payment.");
+            <Runtime as frame_system::Trait>::DbWeight::get().reads_writes(1, 1)
+        } else {
+            error!("transaction-payment migration failed.");
+            <Runtime as frame_system::Trait>::DbWeight::get().reads(1)
+        }
+    }
+
+    fn multisig_migrate_from_utility() -> frame_support::weights::Weight {
+        use frame_support::migration::{put_storage_value, StorageIterator};
+
+        // Removed in https://github.com/paritytech/substrate/commit/cf7432a5ebef122ab685e0b9256a15c722661116
+
+        sp_runtime::print("🕊️  Migrating Multisigs...");
+        for (key, value) in StorageIterator::<
+            pallet_multisig::Multisig<BlockNumber, Balance, AccountId>,
+        >::new(b"Utility", b"Multisigs")
+        .drain()
+        {
+            put_storage_value(b"Multisig", b"Multisigs", &key, value);
+        }
+        sp_runtime::print("🕊️  Done Multisigs.");
+
+        1_000_000_000
+    }
+}
+impl frame_support::traits::OnRuntimeUpgrade for CustomRuntimeUpgradesRc2ToRc6 {
+    fn on_runtime_upgrade() -> frame_support::weights::Weight {
+        let mut weight =
+            CustomRuntimeUpgradesRc2ToRc6::transaction_payment_rename_and_convert_multiplier();
+        weight =
+            weight.saturating_add(CustomRuntimeUpgradesRc2ToRc6::multisig_migrate_from_utility());
+
+        weight
+    }
+}
+
 construct_runtime!(
     pub enum Runtime where
         Block = Block,
@@ -837,6 +913,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllModules,
+    CustomRuntimeUpgradesRc2ToRc6,
 >;
 
 sp_api::impl_runtime_apis! {


### PR DESCRIPTION
## Context
Upgrading straight to rc6 from rc2 caused some issues due to some migrations having been removed. This PR fixes this by adding the required migrations inside the runtime code.

> Fixes [if needed, mention the issues involved].

### Sanity
- [x] I have incremented the runtime version number
- [ ] I have incremented `transaction_version` if needed

### Quality
- [ ] I have added unit tests, and they are passing
- [ ] I have added benchmarks to my pallet
- [ ] I have added the benchmarks to the node
- [ ] I have added potential RPC calls to the node
- [ ] I have eventual custom types to the `types.json` file
- [x] I have added comments and documentation

### Testing
- [x] The node runs fine on a development network
- [x] The node runs fine on a local network
- [x] The node runs fine on an upgraded local network
- [x] The node can synchronize the existing network
