### PR TITLE
fix doc string in amendments pallet

### DIFF
--- a/pallets/amendments/src/lib.rs
+++ b/pallets/amendments/src/lib.rs
@@ -93,7 +93,7 @@ decl_module! {
     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
         fn deposit_event() = default;
 
-        /// Trigger a new challenge to remove an existing member
+        /// Schedule `amendment` to be executed after the configured time, unless vetoed by `VetoOrigin`
         #[weight = 100_000_000]
         fn propose(origin, amendment: Box<T::Amendment>) -> DispatchResult {
             T::SubmissionOrigin::try_origin(origin)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -96,7 +96,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native
     /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     /// `spec_version` and `authoring_version` are the same between Wasm and native.
-    spec_version: 41,
+    spec_version: 42,
 
     /// Version of the implementation of the specification. Nodes are free to ignore this; it
     /// serves only as an indication that the code is different; as long as the other two versions


### PR DESCRIPTION
## Context
Seems like the docstring was erroneous, fix it.

> Fixes [if needed, mention the issues involved].

### Sanity
- [ ] I have incremented the runtime version number
- [ ] I have incremented `transaction_version` if needed

### Quality
- [ ] I have added unit tests, and they are passing
- [ ] I have added benchmarks to my pallet
- [ ] I have added the benchmarks to the node
- [ ] I have added potential RPC calls to the node
- [ ] I have eventual custom types to the `types.json` file
- [ ] I have added comments and documentation

### Testing
- [ ] The node runs fine on a development network
- [ ] The node runs fine on a local network
- [ ] The node runs fine on an upgraded local network
- [ ] The node can synchronize the existing network
