### PR TITLE
fix stall spec

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -141,7 +141,6 @@ pub fn testnet_genesis(
                 .cloned()
                 .map(|k| (k, ENDOWMENT))
                 .chain(oracles.iter().map(|x| (x.clone(), ENDOWMENT)))
-                .chain(initial_authorities.iter().map(|x| (x.0.clone(), ENDOWMENT)))
                 .chain(roots.iter().map(|x| (x.clone(), ENDOWMENT)))
                 .collect(),
         }),
@@ -256,6 +255,31 @@ pub fn local_testnet_config() -> ChainSpec {
         "local_testnet",
         ChainType::Local,
         local_testnet_genesis,
+        vec![],
+        None,
+        None,
+        None,
+        Default::default(),
+    )
+}
+
+fn dummy_testnet_genesis() -> GenesisConfig {
+    testnet_genesis(
+        vec![get_authority_keys_from_seed("Alice")],
+        vec![],
+        vec![],
+        Some(vec![]),
+        Some(vec![]),
+    )
+}
+
+/// Dummy testnet config no balances, alice is a validator
+pub fn dummy_testnet_config() -> ChainSpec {
+    ChainSpec::from_genesis(
+        "Dummy Network",
+        "dummy_network",
+        ChainType::Live,
+        dummy_testnet_genesis,
         vec![],
         None,
         None,

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -55,6 +55,8 @@ impl SubstrateCli for Cli {
         Ok(match id {
             "dev" => Box::new(chain_spec::development_config()),
             "local" => Box::new(chain_spec::local_testnet_config()),
+            // Dummy chain is a chain wiht no accounts and only alice as an authority. Useful for forks
+            "dummy" => Box::new(chain_spec::dummy_testnet_config()),
             "main" => Box::new(chain_spec::main_config()),
             "" | "arcadia" => Box::new(chain_spec::arcadia_config()),
             path => Box::new(chain_spec::ChainSpec::from_json_file(

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -96,7 +96,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native
     /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     /// `spec_version` and `authoring_version` are the same between Wasm and native.
-    spec_version: 42,
+    spec_version: 43,
 
     /// Version of the implementation of the specification. Nodes are free to ignore this; it
     /// serves only as an indication that the code is different; as long as the other two versions
@@ -838,6 +838,46 @@ construct_runtime!(
     }
 );
 
+pub struct RuntimeUpgradeStallFork;
+impl frame_support::traits::OnRuntimeUpgrade for RuntimeUpgradeStallFork {
+    fn on_runtime_upgrade() -> frame_support::weights::Weight {
+        use frame_support::migration::{put_storage_value, StorageIterator};
+        sp_runtime::print("🕊️  Recomputing Grants...");
+
+        for (account_id, grants) in StorageIterator::<
+            Vec<pallet_grants::VestingSchedule<BlockNumber, Balance>>,
+        >::new(b"Vesting", b"VestingSchedules")
+        .drain()
+        {
+            // The network was stopped at block 1905656. We simply remove those blocks from
+            // the start value since the network restarts at block 0.
+
+            let previous_network_stopped_at = 1905656;
+            put_storage_value(
+                b"Vesting",
+                b"VestingSchedules",
+                &account_id,
+                grants
+                    .iter()
+                    .clone()
+                    .map(
+                        |grant| pallet_grants::VestingSchedule::<BlockNumber, Balance> {
+                            start: grant.start.saturating_sub(previous_network_stopped_at),
+                            period: grant.period,
+                            period_count: grant.period_count,
+                            per_period: grant.per_period,
+                        },
+                    )
+                    .collect::<Vec<_>>(),
+            );
+        }
+
+        sp_runtime::print("🕊️  Grants migrated");
+
+        MaximumBlockWeight::get()
+    }
+}
+
 /// The address format for describing accounts.
 pub type Address = <Indices as StaticLookup>::Source;
 /// Block header type as expected by this runtime.
@@ -871,6 +911,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllModules,
+    RuntimeUpgradeStallFork,
 >;
 
 sp_api::impl_runtime_apis! {


### PR DESCRIPTION
- create dummy chain spec to avoid duplicating test balances when forking
- write runtime migration to fix the vesting schedules
- new main chain spec

## Context
This PR modifies the mainnet chain spec to be able to restart the chain with the old network's state.
We had to do a few wizardy:
- implement some runtime migrations to recompute vested grants
- create a "dummy" network to avoid merging a test config with a production one (aka having the test accounts Alice, Bob and others with money)
- make sure the new runtime is part of the chain spec

Tested this locally with success. Next step is to deploy and see what happens.
