### PR TITLE
Eliott/2.0.0 mainnet upgrade

### DIFF
--- a/pallets/grants/src/benchmarking.rs
+++ b/pallets/grants/src/benchmarking.rs
@@ -88,7 +88,7 @@ benchmarks! {
         for x in 0 .. b {
             Module::<T>::do_add_vesting_schedule(&config.granter, &config.grantee, config.schedule.clone())?;
         }
-    }: _(RawOrigin::Signed(config.grantee))
+    }: _(RawOrigin::Signed(config.grantee), config.grantee_lookup)
 
     cancel_all_vesting_schedules {
         let u in 1 .. 1000;

--- a/pallets/grants/src/lib.rs
+++ b/pallets/grants/src/lib.rs
@@ -156,12 +156,14 @@ decl_module! {
         fn deposit_event() = default;
 
         /// Claim funds that have been vested so far
-        #[weight = 30_000_000 + T::DbWeight::get().reads_writes(2, 2)]
-        pub fn claim(origin) {
-            let who = ensure_signed(origin)?;
-            let locked_amount = Self::do_claim(&who);
+        #[weight = 30_000_000 + T::DbWeight::get().reads_writes(3, 2)]
+        pub fn claim(origin, grantee: <T::Lookup as StaticLookup>::Source) {
+            let _who = ensure_signed(origin)?;
+            let dest = T::Lookup::lookup(grantee)?;
 
-            Self::deposit_event(RawEvent::Claimed(who, locked_amount));
+            let locked_amount = Self::do_claim(&dest);
+
+            Self::deposit_event(RawEvent::Claimed(dest, locked_amount));
         }
 
         /// Wire funds to be vested by the receiver

--- a/pallets/grants/src/tests.rs
+++ b/pallets/grants/src/tests.rs
@@ -211,14 +211,14 @@ fn claim_works() {
             // remain locked if not claimed
             assert!(PalletBalances::transfer(Origin::signed(BOB), ALICE, 10).is_err());
             // unlocked after claiming
-            assert_ok!(Vesting::claim(Origin::signed(BOB)));
+            assert_ok!(Vesting::claim(Origin::signed(BOB), BOB));
             assert_ok!(PalletBalances::transfer(Origin::signed(BOB), ALICE, 10));
             // more are still locked
             assert!(PalletBalances::transfer(Origin::signed(BOB), ALICE, 1).is_err());
 
             System::set_block_number(21);
-            // claim more
-            assert_ok!(Vesting::claim(Origin::signed(BOB)));
+            // claim more, alice pays for bob
+            assert_ok!(Vesting::claim(Origin::signed(ALICE), BOB));
             assert_ok!(PalletBalances::transfer(Origin::signed(BOB), ALICE, 10));
             // all used up
             assert_eq!(PalletBalances::free_balance(BOB), 0);


### PR DESCRIPTION
## Context
Mainnet's runtime was still on rc6 due to our phoenix operation. Prepare runtime for 2.0 upgrade which will migrate our refcounts to `u32` as well.