### PR TITLE
fix apply as dispatch origin and make it signed from the module id

### DIFF
--- a/pallets/reserve/src/lib.rs
+++ b/pallets/reserve/src/lib.rs
@@ -126,7 +126,7 @@ decl_module! {
                 .map(|_| ())
                 .or_else(ensure_root)?;
 
-            let res = call.dispatch(frame_system::RawOrigin::Root.into());
+            let res = call.dispatch(frame_system::RawOrigin::Signed(Self::account_id()).into());
 
             Self::deposit_event(RawEvent::ReserveOp(res.map(|_| ()).map_err(|e| e.error)));
         }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -96,7 +96,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native
     /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     /// `spec_version` and `authoring_version` are the same between Wasm and native.
-    spec_version: 44,
+    spec_version: 45,
 
     /// Version of the implementation of the specification. Nodes are free to ignore this; it
     /// serves only as an indication that the code is different; as long as the other two versions


### PR DESCRIPTION
Should have been caught during the previous audits. But basically we were dispatching as `root` instead of the module's account id which prevented us to call some `ensure_signed` functions.
