### PR TITLE
Port `pallet-emergency-shutdown` to Frame v2 pallet macros

### DIFF
--- a/pallets/emergency-shutdown/src/benchmarking.rs
+++ b/pallets/emergency-shutdown/src/benchmarking.rs
@@ -30,12 +30,12 @@ use sp_std::prelude::*;
 use crate::Pallet as EmergencyShutdown;
 
 benchmarks! {
-    toggle {
-        let u in 0 .. 1000;
+	toggle {
+		let u in 0 .. 1000;
 
-        let call = Call::<T>::toggle();
-        let origin = T::ShutdownOrigin::successful_origin();
-    }: { call.dispatch_bypass_filter(origin)? }
+		let call = Call::<T>::toggle();
+		let origin = T::ShutdownOrigin::successful_origin();
+	}: { call.dispatch_bypass_filter(origin)? }
 }
 
 impl_benchmark_test_suite!(

--- a/pallets/emergency-shutdown/src/benchmarking.rs
+++ b/pallets/emergency-shutdown/src/benchmarking.rs
@@ -24,22 +24,22 @@ use super::*;
 
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
 use frame_support::{
-	traits::{EnsureOrigin, UnfilteredDispatchable},
+    traits::{EnsureOrigin, UnfilteredDispatchable},
 };
 use sp_std::prelude::*;
 use crate::Pallet as EmergencyShutdown;
 
 benchmarks! {
-	toggle {
-		let u in 0 .. 1000;
+    toggle {
+        let u in 0 .. 1000;
 
-		let call = Call::<T>::toggle();
-		let origin = T::ShutdownOrigin::successful_origin();
-	}: { call.dispatch_bypass_filter(origin)? }
+        let call = Call::<T>::toggle();
+        let origin = T::ShutdownOrigin::successful_origin();
+    }: { call.dispatch_bypass_filter(origin)? }
 }
 
 impl_benchmark_test_suite!(
-	EmergencyShutdown,
-	crate::tests::new_test_ext(),
-	crate::tests::Test,
+    EmergencyShutdown,
+    crate::tests::new_test_ext(),
+    crate::tests::Test,
 );

--- a/pallets/emergency-shutdown/src/benchmarking.rs
+++ b/pallets/emergency-shutdown/src/benchmarking.rs
@@ -22,9 +22,12 @@
 
 use super::*;
 
-use frame_benchmarking::benchmarks;
-use frame_support::traits::UnfilteredDispatchable;
+use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
+use frame_support::{
+	traits::{EnsureOrigin, UnfilteredDispatchable},
+};
 use sp_std::prelude::*;
+use crate::Pallet as EmergencyShutdown;
 
 benchmarks! {
     toggle {
@@ -35,16 +38,8 @@ benchmarks! {
     }: { call.dispatch_bypass_filter(origin)? }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::tests::{new_test_ext, Test};
-    use frame_support::assert_ok;
-
-    #[test]
-    fn test_benchmarks() {
-        new_test_ext().execute_with(|| {
-            assert_ok!(test_benchmark_toggle::<Test>());
-        });
-    }
-}
+impl_benchmark_test_suite!(
+	EmergencyShutdown,
+	crate::tests::new_test_ext(),
+	crate::tests::Test,
+);

--- a/pallets/emergency-shutdown/src/lib.rs
+++ b/pallets/emergency-shutdown/src/lib.rs
@@ -21,10 +21,9 @@
 //! Handle the ability to notify other pallets that they should stop all
 //! operations, or resume them
 
-mod benchmarking;
-
 #[cfg(test)]
 mod tests;
+mod benchmarking;
 
 pub use pallet::*;
 

--- a/pallets/emergency-shutdown/src/lib.rs
+++ b/pallets/emergency-shutdown/src/lib.rs
@@ -29,52 +29,52 @@ pub use pallet::*;
 
 #[frame_support::pallet]
 pub mod pallet {
-	use frame_support::pallet_prelude::*;
-	use frame_system::pallet_prelude::*;
+    use frame_support::pallet_prelude::*;
+    use frame_system::pallet_prelude::*;
 
-	#[pallet::config]
-	pub trait Config: frame_system::Config {
-		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
-		type ShutdownOrigin: EnsureOrigin<Self::Origin>;
-	}
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+        type ShutdownOrigin: EnsureOrigin<Self::Origin>;
+    }
 
-	#[pallet::pallet]
-	#[pallet::generate_store(pub(super) trait Store)]
-	pub struct Pallet<T>(PhantomData<T>);
+    #[pallet::pallet]
+    #[pallet::generate_store(pub(super) trait Store)]
+    pub struct Pallet<T>(PhantomData<T>);
 
-	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+    #[pallet::hooks]
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 
-	}
+    }
 
-	#[pallet::call]
-	impl<T: Config> Pallet<T> {
-		/// Toggle the shutdown state if authorized to do so.
-		#[pallet::weight(10_000_000)]
-		pub fn toggle(
-			origin: OriginFor<T>,
-		) -> DispatchResultWithPostInfo {
-			T::ShutdownOrigin::try_origin(origin)
-				.map(|_| ())
-				.or_else(ensure_root)?;
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        /// Toggle the shutdown state if authorized to do so.
+        #[pallet::weight(10_000_000)]
+        pub fn toggle(
+            origin: OriginFor<T>,
+        ) -> DispatchResultWithPostInfo {
+            T::ShutdownOrigin::try_origin(origin)
+                .map(|_| ())
+                .or_else(ensure_root)?;
 
-			<Shutdown<T>>::put(!Self::shutdown());
-			Self::deposit_event(Event::ShutdownToggled(Self::shutdown()));
+            <Shutdown<T>>::put(!Self::shutdown());
+            Self::deposit_event(Event::ShutdownToggled(Self::shutdown()));
 
-			Ok(().into())
-		}
-	}
+            Ok(().into())
+        }
+    }
 
-	#[pallet::event]
-	#[pallet::generate_deposit(pub(super) fn deposit_event)]
-	#[pallet::metadata()]
-	pub enum Event<T: Config> {
-		/// Shutdown state was toggled, to either on or off.
-		ShutdownToggled(bool),
-	}
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    #[pallet::metadata()]
+    pub enum Event<T: Config> {
+        /// Shutdown state was toggled, to either on or off.
+        ShutdownToggled(bool),
+    }
 
-	#[pallet::storage]
-	#[pallet::getter(fn shutdown)]
-	pub type Shutdown<T: Config> = StorageValue<_, bool, ValueQuery>;
+    #[pallet::storage]
+    #[pallet::getter(fn shutdown)]
+    pub type Shutdown<T: Config> = StorageValue<_, bool, ValueQuery>;
 
 }

--- a/pallets/emergency-shutdown/src/lib.rs
+++ b/pallets/emergency-shutdown/src/lib.rs
@@ -26,46 +26,56 @@ mod benchmarking;
 #[cfg(test)]
 mod tests;
 
-use frame_support::{
-    decl_event, decl_module, decl_storage, dispatch::DispatchResult, traits::EnsureOrigin,
-};
-use frame_system::ensure_root;
+pub use pallet::*;
 
-/// The module's configuration trait.
-pub trait Config: frame_system::Config {
-    type Event: From<Event> + Into<<Self as frame_system::Config>::Event>;
-    type ShutdownOrigin: EnsureOrigin<Self::Origin>;
-}
+#[frame_support::pallet]
+pub mod pallet {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
 
-decl_storage! {
-    trait Store for Module<T: Config> as EmergencyShutdown {
-        pub Shutdown get(fn shutdown): bool;
-    }
-}
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+		type ShutdownOrigin: EnsureOrigin<Self::Origin>;
+	}
 
-decl_module! {
-    /// The module declaration.
-    pub struct Module<T: Config> for enum Call where origin: T::Origin {
-        fn deposit_event() = default;
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(PhantomData<T>);
 
-        /// Toggle the shutdown state if authorized to do so.
-        #[weight = 10_000_000]
-        pub fn toggle(origin) -> DispatchResult {
-            T::ShutdownOrigin::try_origin(origin)
-                .map(|_| ())
-                .or_else(ensure_root)?;
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 
-            Shutdown::put(!Self::shutdown());
-            Self::deposit_event(Event::ShutdownToggled(Self::shutdown()));
+	}
 
-            Ok(())
-        }
-    }
-}
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Toggle the shutdown state if authorized to do so.
+		#[pallet::weight(10_000_000)]
+		pub fn toggle(
+			origin: OriginFor<T>,
+		) -> DispatchResultWithPostInfo {
+			T::ShutdownOrigin::try_origin(origin)
+				.map(|_| ())
+				.or_else(ensure_root)?;
 
-decl_event!(
-    pub enum Event {
+			<Shutdown<T>>::put(!Self::shutdown());
+			Self::deposit_event(Event::ShutdownToggled(Self::shutdown()));
+
+			Ok(().into())
+		}
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	#[pallet::metadata()]
+	pub enum Event<T: Config> {
         /// Shutdown state was toggled, to either on or off.
         ShutdownToggled(bool),
-    }
-);
+	}
+
+	#[pallet::storage]
+	#[pallet::getter(fn shutdown)]
+	pub type Shutdown<T: Config> = StorageValue<_, bool, ValueQuery>;
+
+}

--- a/pallets/emergency-shutdown/src/lib.rs
+++ b/pallets/emergency-shutdown/src/lib.rs
@@ -70,8 +70,8 @@ pub mod pallet {
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	#[pallet::metadata()]
 	pub enum Event<T: Config> {
-        /// Shutdown state was toggled, to either on or off.
-        ShutdownToggled(bool),
+		/// Shutdown state was toggled, to either on or off.
+		ShutdownToggled(bool),
 	}
 
 	#[pallet::storage]

--- a/pallets/emergency-shutdown/src/tests.rs
+++ b/pallets/emergency-shutdown/src/tests.rs
@@ -24,100 +24,100 @@ use frame_support::{assert_noop, assert_ok, ord_parameter_types, parameter_types
 use frame_system::{EnsureSignedBy, RawOrigin};
 use sp_core::H256;
 use sp_runtime::{
-    testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
-    DispatchError::BadOrigin,
+	testing::Header,
+	traits::{BlakeTwo256, IdentityLookup},
+	DispatchError::BadOrigin,
 };
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
-    pub enum Test where
-        Block = Block,
-        NodeBlock = Block,
-        UncheckedExtrinsic = UncheckedExtrinsic,
-    {
-        System: frame_system::{Module, Call, Config, Storage, Event<T>},
-        TestModule: pallet_emergency_shutdown::{Module, Call, Storage, Event<T>},
-    }
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		TestModule: pallet_emergency_shutdown::{Module, Call, Storage, Event<T>},
+	}
 );
 
 parameter_types! {
-    pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u64 = 250;
 }
 impl frame_system::Config for Test {
-    type Origin = Origin;
-    type Call = Call;
-    type BlockWeights = ();
-    type BlockLength = ();
-    type SS58Prefix = ();
-    type Index = u64;
-    type BlockNumber = u64;
-    type Hash = H256;
-    type Hashing = BlakeTwo256;
-    type AccountId = u64;
-    type Lookup = IdentityLookup<Self::AccountId>;
-    type Header = Header;
-    type Event = ();
-    type BlockHashCount = BlockHashCount;
-    type Version = ();
-    type PalletInfo = PalletInfo;
-    type AccountData = ();
-    type OnNewAccount = ();
-    type OnKilledAccount = ();
-    type DbWeight = ();
-    type BaseCallFilter = ();
-    type SystemWeightInfo = ();
+	type Origin = Origin;
+	type Call = Call;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type SS58Prefix = ();
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = ();
+	type BlockHashCount = BlockHashCount;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type DbWeight = ();
+	type BaseCallFilter = ();
+	type SystemWeightInfo = ();
 }
 
 ord_parameter_types! {
-    pub const Admin: u64 = 1;
+	pub const Admin: u64 = 1;
 }
 impl Config for Test {
-    type Event = ();
-    type ShutdownOrigin = EnsureSignedBy<Admin, u64>;
+	type Event = ();
+	type ShutdownOrigin = EnsureSignedBy<Admin, u64>;
 }
 
 // This function basically just builds a genesis storage key/value store according to
 // our desired mockup.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-    frame_system::GenesisConfig::default()
-        .build_storage::<Test>()
-        .unwrap()
-        .into()
+	frame_system::GenesisConfig::default()
+		.build_storage::<Test>()
+		.unwrap()
+		.into()
 }
 
 #[test]
 fn root_toggle() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(TestModule::toggle(RawOrigin::Root.into()));
-    })
+	new_test_ext().execute_with(|| {
+		assert_ok!(TestModule::toggle(RawOrigin::Root.into()));
+	})
 }
 
 #[test]
 fn shutdown_origin_toggle() {
-    new_test_ext().execute_with(|| {
-        assert_ok!(TestModule::toggle(Origin::signed(Admin::get())));
-    })
+	new_test_ext().execute_with(|| {
+		assert_ok!(TestModule::toggle(Origin::signed(Admin::get())));
+	})
 }
 
 #[test]
 fn toggle_on_off() {
-    new_test_ext().execute_with(|| {
-        assert_eq!(TestModule::shutdown(), false);
+	new_test_ext().execute_with(|| {
+		assert_eq!(TestModule::shutdown(), false);
 
-        assert_ok!(TestModule::toggle(RawOrigin::Root.into()));
-        assert_eq!(TestModule::shutdown(), true);
+		assert_ok!(TestModule::toggle(RawOrigin::Root.into()));
+		assert_eq!(TestModule::shutdown(), true);
 
-        assert_ok!(TestModule::toggle(RawOrigin::Root.into()));
-        assert_eq!(TestModule::shutdown(), false);
-    })
+		assert_ok!(TestModule::toggle(RawOrigin::Root.into()));
+		assert_eq!(TestModule::shutdown(), false);
+	})
 }
 
 #[test]
 fn non_origin_fails() {
-    new_test_ext().execute_with(|| {
-        assert_noop!(TestModule::toggle(Origin::signed(0)), BadOrigin);
-    })
+	new_test_ext().execute_with(|| {
+		assert_noop!(TestModule::toggle(Origin::signed(0)), BadOrigin);
+	})
 }

--- a/pallets/emergency-shutdown/src/tests.rs
+++ b/pallets/emergency-shutdown/src/tests.rs
@@ -24,100 +24,100 @@ use frame_support::{assert_noop, assert_ok, ord_parameter_types, parameter_types
 use frame_system::{EnsureSignedBy, RawOrigin};
 use sp_core::H256;
 use sp_runtime::{
-	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
-	DispatchError::BadOrigin,
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
+    DispatchError::BadOrigin,
 };
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 frame_support::construct_runtime!(
-	pub enum Test where
-		Block = Block,
-		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
-	{
-		System: frame_system::{Module, Call, Config, Storage, Event<T>},
-		TestModule: pallet_emergency_shutdown::{Module, Call, Storage, Event<T>},
-	}
+    pub enum Test where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic,
+    {
+        System: frame_system::{Module, Call, Config, Storage, Event<T>},
+        TestModule: pallet_emergency_shutdown::{Module, Call, Storage, Event<T>},
+    }
 );
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+    pub const BlockHashCount: u64 = 250;
 }
 impl frame_system::Config for Test {
-	type Origin = Origin;
-	type Call = Call;
-	type BlockWeights = ();
-	type BlockLength = ();
-	type SS58Prefix = ();
-	type Index = u64;
-	type BlockNumber = u64;
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
-	type AccountId = u64;
-	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
-	type Event = ();
-	type BlockHashCount = BlockHashCount;
-	type Version = ();
-	type PalletInfo = PalletInfo;
-	type AccountData = ();
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
-	type DbWeight = ();
-	type BaseCallFilter = ();
-	type SystemWeightInfo = ();
+    type Origin = Origin;
+    type Call = Call;
+    type BlockWeights = ();
+    type BlockLength = ();
+    type SS58Prefix = ();
+    type Index = u64;
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = u64;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = ();
+    type BlockHashCount = BlockHashCount;
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = ();
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type DbWeight = ();
+    type BaseCallFilter = ();
+    type SystemWeightInfo = ();
 }
 
 ord_parameter_types! {
-	pub const Admin: u64 = 1;
+    pub const Admin: u64 = 1;
 }
 impl Config for Test {
-	type Event = ();
-	type ShutdownOrigin = EnsureSignedBy<Admin, u64>;
+    type Event = ();
+    type ShutdownOrigin = EnsureSignedBy<Admin, u64>;
 }
 
 // This function basically just builds a genesis storage key/value store according to
 // our desired mockup.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	frame_system::GenesisConfig::default()
-		.build_storage::<Test>()
-		.unwrap()
-		.into()
+    frame_system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap()
+        .into()
 }
 
 #[test]
 fn root_toggle() {
-	new_test_ext().execute_with(|| {
-		assert_ok!(TestModule::toggle(RawOrigin::Root.into()));
-	})
+    new_test_ext().execute_with(|| {
+        assert_ok!(TestModule::toggle(RawOrigin::Root.into()));
+    })
 }
 
 #[test]
 fn shutdown_origin_toggle() {
-	new_test_ext().execute_with(|| {
-		assert_ok!(TestModule::toggle(Origin::signed(Admin::get())));
-	})
+    new_test_ext().execute_with(|| {
+        assert_ok!(TestModule::toggle(Origin::signed(Admin::get())));
+    })
 }
 
 #[test]
 fn toggle_on_off() {
-	new_test_ext().execute_with(|| {
-		assert_eq!(TestModule::shutdown(), false);
+    new_test_ext().execute_with(|| {
+        assert_eq!(TestModule::shutdown(), false);
 
-		assert_ok!(TestModule::toggle(RawOrigin::Root.into()));
-		assert_eq!(TestModule::shutdown(), true);
+        assert_ok!(TestModule::toggle(RawOrigin::Root.into()));
+        assert_eq!(TestModule::shutdown(), true);
 
-		assert_ok!(TestModule::toggle(RawOrigin::Root.into()));
-		assert_eq!(TestModule::shutdown(), false);
-	})
+        assert_ok!(TestModule::toggle(RawOrigin::Root.into()));
+        assert_eq!(TestModule::shutdown(), false);
+    })
 }
 
 #[test]
 fn non_origin_fails() {
-	new_test_ext().execute_with(|| {
-		assert_noop!(TestModule::toggle(Origin::signed(0)), BadOrigin);
-	})
+    new_test_ext().execute_with(|| {
+        assert_noop!(TestModule::toggle(Origin::signed(0)), BadOrigin);
+    })
 }

--- a/pallets/emergency-shutdown/src/tests.rs
+++ b/pallets/emergency-shutdown/src/tests.rs
@@ -39,7 +39,7 @@ frame_support::construct_runtime!(
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
         System: frame_system::{Module, Call, Config, Storage, Event<T>},
-        TestModule: pallet_emergency_shutdown::{Module, Call, Storage, Event},
+        TestModule: pallet_emergency_shutdown::{Module, Call, Storage, Event<T>},
     }
 );
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -898,7 +898,7 @@ construct_runtime!(
         // Nodle Stack
         PkiTcr: pallet_tcr::<Instance1>::{Module, Call, Storage, Event<T>},
         PkiRootOfTrust: pallet_root_of_trust::{Module, Call, Storage, Event<T>},
-        EmergencyShutdown: pallet_emergency_shutdown::{Module, Call, Event, Storage},
+        EmergencyShutdown: pallet_emergency_shutdown::{Module, Call, Event<T>, Storage},
         Allocations: pallet_allocations::{Module, Call, Event<T>, Storage},
         AllocationsOracles: pallet_membership::<Instance5>::{Module, Call, Storage, Event<T>, Config<T>},
     }


### PR DESCRIPTION
Port `pallet-emergency-shutdown` to Frame v2 pallet macros