### PR TITLE
grants cancelling: limit to free balance to support corrupted states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 
 # Mac OS annoyances
 .DS_Store
+
+.vscode

--- a/pallets/grants/src/benchmarking.rs
+++ b/pallets/grants/src/benchmarking.rs
@@ -32,6 +32,7 @@ const SEED: u32 = 0;
 struct BenchmarkConfig<T: Config> {
     granter: T::AccountId,
     grantee: T::AccountId,
+    granter_lookup: <T::Lookup as StaticLookup>::Source,
     grantee_lookup: <T::Lookup as StaticLookup>::Source,
     collector_lookup: <T::Lookup as StaticLookup>::Source,
     schedule: VestingSchedule<T::BlockNumber, BalanceOf<T>>,
@@ -41,6 +42,7 @@ fn create_shared_config<T: Config>(u: u32) -> BenchmarkConfig<T> {
     let granter: T::AccountId = account("granter", u, SEED);
     let grantee: T::AccountId = account("grantee", u, SEED);
     let collector: T::AccountId = account("collector", u, SEED);
+    let granter_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(granter.clone());
     let grantee_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(grantee.clone());
     let collector_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(collector);
 
@@ -56,6 +58,7 @@ fn create_shared_config<T: Config>(u: u32) -> BenchmarkConfig<T> {
     BenchmarkConfig {
         granter,
         grantee,
+        granter_lookup,
         grantee_lookup,
         collector_lookup,
         schedule,
@@ -99,7 +102,7 @@ benchmarks! {
             Module::<T>::do_add_vesting_schedule(&config.granter, &config.grantee, config.schedule.clone())?;
         }
 
-        let call = Call::<T>::cancel_all_vesting_schedules(config.grantee_lookup, config.collector_lookup);
+        let call = Call::<T>::cancel_all_vesting_schedules(config.grantee_lookup, config.collector_lookup, config.granter_lookup);
         let origin = T::CancelOrigin::successful_origin();
     }: { call.dispatch_bypass_filter(origin)? }
 }

--- a/pallets/grants/src/benchmarking.rs
+++ b/pallets/grants/src/benchmarking.rs
@@ -102,7 +102,7 @@ benchmarks! {
             Module::<T>::do_add_vesting_schedule(&config.granter, &config.grantee, config.schedule.clone())?;
         }
 
-        let call = Call::<T>::cancel_all_vesting_schedules(config.grantee_lookup, config.collector_lookup, config.granter_lookup);
+        let call = Call::<T>::cancel_all_vesting_schedules(config.grantee_lookup, config.collector_lookup, config.granter_lookup, true);
         let origin = T::CancelOrigin::successful_origin();
     }: { call.dispatch_bypass_filter(origin)? }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -109,7 +109,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native
     /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     /// `spec_version` and `authoring_version` are the same between Wasm and native.
-    spec_version: 47,
+    spec_version: 48,
 
     /// Version of the implementation of the specification. Nodes are free to ignore this; it
     /// serves only as an indication that the code is different; as long as the other two versions


### PR DESCRIPTION
Due to the previous bug which we fixed we may have some grants with a "corrupted" state which would make it impossible to correctly cancel and redo those grants. This PR fixes this
