### PR TITLE
no longer run tests on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Stop running tests on macos as it slows things down for not much benefits. The code runs the same on ubuntu and macos anyways.
