### PR TITLE
phoenix 2

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -313,33 +313,6 @@ pub fn local_testnet_config() -> ChainSpec {
     )
 }
 
-fn dummy_testnet_genesis() -> GenesisConfig {
-    testnet_genesis(
-        vec![get_authority_keys_from_seed("Alice")],
-        vec![],
-        vec![],
-        Some(vec![get_account_id_from_seed::<sr25519::Public>(
-            "Alice//stash",
-        )]),
-        Some(vec![]),
-    )
-}
-
-/// Dummy testnet config no balances, alice is a validator
-pub fn dummy_testnet_config() -> ChainSpec {
-    ChainSpec::from_genesis(
-        "Dummy Network",
-        "dummy_network",
-        ChainType::Live,
-        dummy_testnet_genesis,
-        vec![],
-        None,
-        Some("nodl"),
-        Some(build_local_properties()),
-        Default::default(),
-    )
-}
-
 /// Arcadia config, from json chainspec
 pub fn arcadia_config() -> ChainSpec {
     ChainSpec::from_json_bytes(&include_bytes!("../res/arcadia.json")[..]).unwrap()
@@ -363,11 +336,6 @@ pub(crate) mod tests {
     #[test]
     fn test_create_local_testnet_chain_spec() {
         local_testnet_config().build_storage().unwrap();
-    }
-
-    #[test]
-    fn test_create_dummy_testnet_chain_spec() {
-        dummy_testnet_config().build_storage().unwrap();
     }
 
     #[test]

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -318,7 +318,9 @@ fn dummy_testnet_genesis() -> GenesisConfig {
         vec![get_authority_keys_from_seed("Alice")],
         vec![],
         vec![],
-        Some(vec![]),
+        Some(vec![get_account_id_from_seed::<sr25519::Public>(
+            "Alice//stash",
+        )]),
         Some(vec![]),
     )
 }
@@ -361,6 +363,11 @@ pub(crate) mod tests {
     #[test]
     fn test_create_local_testnet_chain_spec() {
         local_testnet_config().build_storage().unwrap();
+    }
+
+    #[test]
+    fn test_create_dummy_testnet_chain_spec() {
+        dummy_testnet_config().build_storage().unwrap();
     }
 
     #[test]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -55,8 +55,6 @@ impl SubstrateCli for Cli {
         Ok(match id {
             "dev" => Box::new(chain_spec::development_config()),
             "local" => Box::new(chain_spec::local_testnet_config()),
-            // Dummy chain is a chain wiht no accounts and only alice as an authority. Useful for forks
-            "dummy" => Box::new(chain_spec::dummy_testnet_config()),
             "main" => Box::new(chain_spec::main_config()),
             "" | "arcadia" => Box::new(chain_spec::arcadia_config()),
             path => Box::new(chain_spec::ChainSpec::from_json_file(

--- a/pallets/poa/src/lib.rs
+++ b/pallets/poa/src/lib.rs
@@ -85,7 +85,12 @@ impl<T: Config> Convert<T::AccountId, Option<FullIdentification>> for FullIdenti
 type SessionIndex = u32; // A shim while waiting for this type to be exposed by `session`
 impl<T: Config> SessionManager<T::AccountId> for Pallet<T> {
     fn new_session(_: SessionIndex) -> Option<Vec<T::AccountId>> {
-        Some(<Validators<T>>::get())
+        let all_keys = Validators::<T>::get();
+        if all_keys.is_empty() {
+            None
+        } else {
+            Some(all_keys)
+        }
     }
 
     fn start_session(_: SessionIndex) {}

--- a/pallets/poa/src/tests.rs
+++ b/pallets/poa/src/tests.rs
@@ -147,3 +147,11 @@ fn new_session_return_members() {
         assert_eq!(TestModule::new_session(0), Some(vec![VALIDATOR]));
     })
 }
+
+#[test]
+fn return_none_if_set_empty() {
+    new_test_ext().execute_with(|| {
+        TestModule::initialize_members(&[]);
+        assert_eq!(TestModule::new_session(0), None);
+    })
+}

--- a/runtime/src/version.rs
+++ b/runtime/src/version.rs
@@ -40,7 +40,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native
     /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     /// `spec_version` and `authoring_version` are the same between Wasm and native.
-    spec_version: 48,
+    spec_version: 49,
 
     /// Version of the implementation of the specification. Nodes are free to ignore this; it
     /// serves only as an indication that the code is different; as long as the other two versions


### PR DESCRIPTION
Last upgrade cleared the validator set on the mainnet. Fixes that via the `fork-off` script. 
