### PR TITLE
hotfix reserve apply as

### DIFF
--- a/pallets/reserve/src/lib.rs
+++ b/pallets/reserve/src/lib.rs
@@ -131,7 +131,7 @@ pub mod pallet {
                 .map(|_| ())
                 .or_else(ensure_root)?;
 
-            let res = call.dispatch(frame_system::RawOrigin::Root.into());
+            let res = call.dispatch(frame_system::RawOrigin::Signed(Self::account_id()).into());
 
             Self::deposit_event(Event::ReserveOp(res.map(|_| ()).map_err(|e| e.error)));
 

--- a/runtime/src/version.rs
+++ b/runtime/src/version.rs
@@ -40,7 +40,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native
     /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     /// `spec_version` and `authoring_version` are the same between Wasm and native.
-    spec_version: 50,
+    spec_version: 51,
 
     /// Version of the implementation of the specification. Nodes are free to ignore this; it
     /// serves only as an indication that the code is different; as long as the other two versions


### PR DESCRIPTION
Seems like we had a regression here. Get rid of the runtime migrations and prepare for a hotfix upgrade.
