### PR TITLE
make the dev setup more similar to a prod setup

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -259,7 +259,12 @@ pub fn testnet_genesis(
 fn development_config_genesis() -> GenesisConfig {
     testnet_genesis(
         vec![get_authority_keys_from_seed("Alice")],
-        vec![get_account_id_from_seed::<sr25519::Public>("Alice")],
+        vec![
+            get_account_id_from_seed::<sr25519::Public>("Alice"),
+            get_account_id_from_seed::<sr25519::Public>("Bob"),
+            get_account_id_from_seed::<sr25519::Public>("Charlie"),
+            get_account_id_from_seed::<sr25519::Public>("Dave"),
+        ],
         vec![get_account_id_from_seed::<sr25519::Public>("Ferdie")],
         None,
         None,


### PR DESCRIPTION
When testing our allocations script we always have to add more authorities to our committees to match what we have in prod. This changes the chain spec to match this and avoid having to do it manually again.
