### PR TITLE
Added event parameter annotation for NewAllocation event

### DIFF
--- a/pallets/allocations/src/lib.rs
+++ b/pallets/allocations/src/lib.rs
@@ -139,7 +139,7 @@ pub mod pallet {
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     #[pallet::metadata(T::AccountId = "AccountId", BalanceOf<T> = "Balance")]
     pub enum Event<T: Config> {
-        /// An allocation was triggered
+        /// An allocation was triggered [who, value, fee, proof]
         NewAllocation(T::AccountId, BalanceOf<T>, BalanceOf<T>, Vec<u8>),
     }
 

--- a/pallets/allocations/src/lib.rs
+++ b/pallets/allocations/src/lib.rs
@@ -139,7 +139,7 @@ pub mod pallet {
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     #[pallet::metadata(T::AccountId = "AccountId", BalanceOf<T> = "Balance")]
     pub enum Event<T: Config> {
-        /// An allocation was triggered [who, value, fee, proof]
+        /// An allocation was triggered \[who, value, fee, proof\]
         NewAllocation(T::AccountId, BalanceOf<T>, BalanceOf<T>, Vec<u8>),
     }
 

--- a/pallets/grants/src/lib.rs
+++ b/pallets/grants/src/lib.rs
@@ -209,7 +209,7 @@ pub mod pallet {
         VestingScheduleOf<T> = "VestingSchedule",
     )]
     pub enum Event<T: Config> {
-        /// Added new vesting schedule [from, to, vesting_schedule]
+        /// Added new vesting schedule \[from, to, vesting_schedule\]
         VestingScheduleAdded(T::AccountId, T::AccountId, VestingScheduleOf<T>),
         /// Claimed vesting [who, locked_amount]
         Claimed(T::AccountId, BalanceOf<T>),

--- a/pallets/grants/src/lib.rs
+++ b/pallets/grants/src/lib.rs
@@ -211,7 +211,7 @@ pub mod pallet {
     pub enum Event<T: Config> {
         /// Added new vesting schedule \[from, to, vesting_schedule\]
         VestingScheduleAdded(T::AccountId, T::AccountId, VestingScheduleOf<T>),
-        /// Claimed vesting [who, locked_amount]
+        /// Claimed vesting \[who, locked_amount\]
         Claimed(T::AccountId, BalanceOf<T>),
         /// Canceled all vesting schedules [who]
         VestingSchedulesCanceled(T::AccountId),

--- a/pallets/grants/src/lib.rs
+++ b/pallets/grants/src/lib.rs
@@ -209,11 +209,11 @@ pub mod pallet {
         VestingScheduleOf<T> = "VestingSchedule",
     )]
     pub enum Event<T: Config> {
-        /// Added new vesting schedule (from, to, vesting_schedule)
+        /// Added new vesting schedule [from, to, vesting_schedule]
         VestingScheduleAdded(T::AccountId, T::AccountId, VestingScheduleOf<T>),
-        /// Claimed vesting (who, locked_amount)
+        /// Claimed vesting [who, locked_amount]
         Claimed(T::AccountId, BalanceOf<T>),
-        /// Canceled all vesting schedules (who)
+        /// Canceled all vesting schedules [who]
         VestingSchedulesCanceled(T::AccountId),
     }
 

--- a/pallets/grants/src/lib.rs
+++ b/pallets/grants/src/lib.rs
@@ -213,7 +213,7 @@ pub mod pallet {
         VestingScheduleAdded(T::AccountId, T::AccountId, VestingScheduleOf<T>),
         /// Claimed vesting \[who, locked_amount\]
         Claimed(T::AccountId, BalanceOf<T>),
-        /// Canceled all vesting schedules [who]
+        /// Canceled all vesting schedules \[who\]
         VestingSchedulesCanceled(T::AccountId),
     }
 


### PR DESCRIPTION

## Context
In block explorer we indexing events. To do it we store it as json field in Postgresql. But polkadot.js library (and substrate API interfaces) doesn't provide information about field names. But they put it in documentation like it

```
/// Transfer succeeded. \[from, to, value\]
Transfer(T::AccountId, T::AccountId, T::Balance),
``` 

This PR contains updates in `NewAllocation` documentation


### Sanity
- [ ] I have incremented the runtime version number
- [ ] I have incremented `transaction_version` if needed

### Quality
- [ ] I have added unit tests, and they are passing
- [ ] I have added benchmarks to my pallet
- [ ] I have added the benchmarks to the node
- [ ] I have added potential RPC calls to the node
- [ ] I have eventual custom types to the `types.json` file
- [ ] I have added comments and documentation

### Testing
- [ ] The node runs fine on a development network
- [ ] The node runs fine on a local network
- [ ] The node runs fine on an upgraded local network
- [ ] The node can synchronize the existing network