### PR TITLE
Bug_fix: nominator_nominate() is updated with inc_consumers()

### DIFF
--- a/pallets/nodle-staking/src/lib.rs
+++ b/pallets/nodle-staking/src/lib.rs
@@ -230,10 +230,6 @@ pub mod pallet {
 
             log::debug!("validator_join_pool:[{:#?}]", line!(),);
 
-            system::Pallet::<T>::inc_consumers(&acc).map_err(|_| <Error<T>>::BadState)?;
-
-            log::debug!("validator_join_pool:[{:#?}]", line!(),);
-
             T::Currency::set_lock(T::StakingLockId::get(), &acc, bond, WithdrawReasons::all());
 
             let validator = Validator::new(acc.clone(), bond);
@@ -476,11 +472,6 @@ pub mod pallet {
             <Total<T>>::mutate(|x| *x = x.saturating_add(amount));
             <ValidatorState<T>>::insert(&validator, validator_state);
             <NominatorState<T>>::insert(&nominator_acc, nominator_state);
-
-            if !do_add_nomination {
-                system::Pallet::<T>::inc_consumers(&nominator_acc)
-                    .map_err(|_| <Error<T>>::BadState)?;
-            }
 
             Self::deposit_event(Event::Nomination(
                 nominator_acc,
@@ -1457,8 +1448,6 @@ pub mod pallet {
             } else if Self::is_nominator(&controller) {
                 <NominatorState<T>>::remove(controller);
             }
-
-            system::Pallet::<T>::dec_consumers(controller);
             Ok(())
         }
 

--- a/pallets/nodle-staking/src/lib.rs
+++ b/pallets/nodle-staking/src/lib.rs
@@ -477,6 +477,11 @@ pub mod pallet {
             <ValidatorState<T>>::insert(&validator, validator_state);
             <NominatorState<T>>::insert(&nominator_acc, nominator_state);
 
+            if !do_add_nomination {
+                system::Pallet::<T>::inc_consumers(&nominator_acc)
+                    .map_err(|_| <Error<T>>::BadState)?;
+            }
+
             Self::deposit_event(Event::Nomination(
                 nominator_acc,
                 amount,

--- a/pallets/nodle-staking/src/tests.rs
+++ b/pallets/nodle-staking/src/tests.rs
@@ -1061,6 +1061,17 @@ fn multiple_nominations() {
 
             assert_eq!(NodleStaking::total(), 140);
 
+            assert_eq!(System::consumers(&1), 2);
+            assert_eq!(System::consumers(&2), 2);
+            assert_eq!(System::consumers(&3), 2);
+            assert_eq!(System::consumers(&4), 2);
+            assert_eq!(System::consumers(&5), 2);
+            assert_eq!(System::consumers(&6), 1);
+            assert_eq!(System::consumers(&7), 1);
+            assert_eq!(System::consumers(&8), 1);
+            assert_eq!(System::consumers(&9), 1);
+            assert_eq!(System::consumers(&10), 1);
+
             assert_noop!(
                 NodleStaking::nominator_nominate(Origin::signed(6), 1, 10),
                 Error::<Test>::AlreadyNominatedValidator,
@@ -1218,6 +1229,14 @@ fn multiple_nominations() {
             expected.append(&mut new5);
             assert_eq!(events(), expected);
 
+            assert_eq!(System::consumers(&2), 1);
+
+            assert_eq!(System::consumers(&6), 1);
+            assert_eq!(System::consumers(&7), 1);
+            assert_eq!(System::consumers(&8), 1);
+            assert_eq!(System::consumers(&9), 1);
+            assert_eq!(System::consumers(&10), 1);
+
             assert_ok!(NodleStaking::withdraw_unbonded(Origin::signed(6)));
             assert_ok!(NodleStaking::withdraw_unbonded(Origin::signed(7)));
             assert_ok!(NodleStaking::withdraw_unbonded(Origin::signed(8)));
@@ -1234,6 +1253,12 @@ fn multiple_nominations() {
 
             expected.append(&mut new6);
             assert_eq!(events(), expected);
+
+            assert_eq!(System::consumers(&6), 1);
+            assert_eq!(System::consumers(&7), 1);
+            assert_eq!(System::consumers(&8), 0);
+            assert_eq!(System::consumers(&9), 0);
+            assert_eq!(System::consumers(&10), 1);
 
             assert_eq!(NodleStaking::nominator_state(6).unwrap().total, 30);
             assert_eq!(NodleStaking::nominator_state(7).unwrap().total, 10);
@@ -1288,6 +1313,17 @@ fn multiple_nominations() {
             assert_eq!(Balances::total_balance(&10), 100);
 
             assert_eq!(NodleStaking::total(), 120);
+
+            assert_eq!(System::consumers(&1), 2);
+            assert_eq!(System::consumers(&2), 1);
+            assert_eq!(System::consumers(&3), 2);
+            assert_eq!(System::consumers(&4), 2);
+            assert_eq!(System::consumers(&5), 2);
+            assert_eq!(System::consumers(&6), 1);
+            assert_eq!(System::consumers(&7), 1);
+            assert_eq!(System::consumers(&8), 0);
+            assert_eq!(System::consumers(&9), 0);
+            assert_eq!(System::consumers(&10), 1);
 
             // tst_log!(debug, "[{:#?}]=> - {:#?}", line!(), mock::events());
         });


### PR DESCRIPTION
`T::Currency::set_lock()` & `T::Currency::remove_lock()` are used to update the account consumers.
`system::Pallet::<T>::inc_consumers()` & `system::Pallet::<T>::dec_consumers()` are removed to avoid 
duplicate functionality. 
