### PR TITLE
reset dev chain to one validator only

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -254,9 +254,7 @@ pub fn testnet_genesis(
 fn development_config_genesis() -> GenesisConfig {
     testnet_genesis(
         vec![get_authority_keys_from_seed("Alice")],
-        vec![
-            get_account_id_from_seed::<sr25519::Public>("Alice"),
-        ],
+        vec![get_account_id_from_seed::<sr25519::Public>("Alice")],
         vec![get_account_id_from_seed::<sr25519::Public>("Ferdie")],
         None,
         None,

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -256,9 +256,6 @@ fn development_config_genesis() -> GenesisConfig {
         vec![get_authority_keys_from_seed("Alice")],
         vec![
             get_account_id_from_seed::<sr25519::Public>("Alice"),
-            get_account_id_from_seed::<sr25519::Public>("Bob"),
-            get_account_id_from_seed::<sr25519::Public>("Charlie"),
-            get_account_id_from_seed::<sr25519::Public>("Dave"),
         ],
         vec![get_account_id_from_seed::<sr25519::Public>("Ferdie")],
         None,


### PR DESCRIPTION
Normally the dev spec is used to run a mono node to develop against. This reverts previous changes to go back to this state.
