### PR TITLE
pallet::event type or metadata changes to adopt for chain-minions client

### DIFF
--- a/pallets/grants/src/lib.rs
+++ b/pallets/grants/src/lib.rs
@@ -49,6 +49,7 @@ pub type BalanceOf<T> =
     <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 pub type VestingScheduleOf<T> =
     VestingSchedule<<T as frame_system::Config>::BlockNumber, BalanceOf<T>>;
+pub type VestingScheduleOfColl<T> = Vec<VestingScheduleOf<T>>;
 pub type ScheduledGrant<T> = (
     <T as frame_system::Config>::BlockNumber,
     <T as frame_system::Config>::BlockNumber,
@@ -262,10 +263,11 @@ pub mod pallet {
     #[pallet::event]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     #[pallet::metadata(
-        T::AccountId = "AccountId",
-        BalanceOf<T> = "Balance",
-        VestingScheduleOf<T> = "VestingSchedule",
-    )]
+		T::AccountId = "AccountId",
+		BalanceOf<T> = "Balance",
+		VestingScheduleOf<T> = "VestingSchedule",
+		VestingScheduleOfColl<T> = "VestingScheduleOfColl"
+	)]
     pub enum Event<T: Config> {
         /// Added new vesting schedule \[from, to, vesting_schedule\]
         VestingScheduleAdded(T::AccountId, T::AccountId, VestingScheduleOf<T>),
@@ -274,7 +276,7 @@ pub mod pallet {
         /// Canceled all vesting schedules \[who\]
         VestingSchedulesCanceled(T::AccountId),
         /// Overwritting vesting schedules \[who, vesting_schedules, locked_amount\]
-        VestingOverwritten(T::AccountId, Vec<VestingScheduleOf<T>>, BalanceOf<T>),
+        VestingOverwritten(T::AccountId, VestingScheduleOfColl<T>, BalanceOf<T>),
     }
 
     #[pallet::error]

--- a/pallets/nodle-staking/src/lib.rs
+++ b/pallets/nodle-staking/src/lib.rs
@@ -72,6 +72,8 @@ pub mod pallet {
 
     pub use hooks::{SessionInterface, StashOf};
 
+    pub(crate) type StakingInvulnerables<T> = Vec<<T as frame_system::Config>::AccountId>;
+
     pub(crate) type BalanceOf<T> =
         <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
@@ -1083,10 +1085,15 @@ pub mod pallet {
 
     #[pallet::event]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
-    #[pallet::metadata(T::AccountId = "AccountId", BalanceOf<T> = "Balance")]
+    #[pallet::metadata(
+		T::AccountId = "AccountId",
+		BalanceOf<T> = "Balance",
+		T::BlockNumber = "BlockNumber",
+		StakingInvulnerables<T> = "StakingInvulnerables"
+	)]
     pub enum Event<T: Config> {
         /// Updated InVulnerable validator list \[validator_list\],
-        NewInvulnerables(Vec<T::AccountId>),
+        NewInvulnerables(StakingInvulnerables<T>),
         /// Updated total validators per session \[old, new\],
         TotalSelectedSet(u32, u32),
         /// Updated staking config, maximum Validators allowed to join the validators pool
@@ -1200,7 +1207,7 @@ pub mod pallet {
     /// invulnerables) and restricted to testnets.
     #[pallet::storage]
     #[pallet::getter(fn invulnerables)]
-    pub(crate) type Invulnerables<T: Config> = StorageValue<_, Vec<T::AccountId>, ValueQuery>;
+    pub(crate) type Invulnerables<T: Config> = StorageValue<_, StakingInvulnerables<T>, ValueQuery>;
 
     /// Maximum Validators allowed to join the validators pool
     #[pallet::storage]

--- a/pallets/root-of-trust/Cargo.toml
+++ b/pallets/root-of-trust/Cargo.toml
@@ -19,9 +19,9 @@ std = [
   "sp-std/std",
 ]
 runtime-benchmarks = [
-	"frame-benchmarking",
+  "frame-benchmarking",
   "frame-system/runtime-benchmarks",
-	"frame-support/runtime-benchmarks",
+  "frame-support/runtime-benchmarks",
 ]
 
 [dependencies]


### PR DESCRIPTION
Types or metadata part of pallet::event are modified to adopt
"substrate-subext" EventTypeRegistry