### PR TITLE
add staking-local spec

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -312,6 +312,38 @@ pub fn local_testnet_config() -> ChainSpec {
     )
 }
 
+#[cfg(feature = "with-staking")]
+fn local_staking_genesis() -> GenesisConfig {
+    testnet_genesis(
+        vec![get_authority_keys_from_seed("Alice")],
+        vec![
+            get_account_id_from_seed::<sr25519::Public>("Alice"),
+            get_account_id_from_seed::<sr25519::Public>("Bob"),
+            get_account_id_from_seed::<sr25519::Public>("Charlie"),
+            get_account_id_from_seed::<sr25519::Public>("Dave"),
+        ],
+        vec![get_account_id_from_seed::<sr25519::Public>("Ferdie")],
+        None,
+        None,
+    )
+}
+
+/// Local testnet config to test the staking pallet
+#[cfg(feature = "with-staking")]
+pub fn local_staking_config() -> ChainSpec {
+    ChainSpec::from_genesis(
+        "Local Staking Testnet",
+        "local_staking_testnet",
+        ChainType::Local,
+        local_staking_genesis,
+        vec![],
+        None,
+        Some("nodl"),
+        Some(build_local_properties()),
+        Default::default(),
+    )
+}
+
 /// Arcadia config, from json chainspec
 pub fn arcadia_config() -> ChainSpec {
     ChainSpec::from_json_bytes(&include_bytes!("../res/arcadia.json")[..]).unwrap()
@@ -335,6 +367,12 @@ pub(crate) mod tests {
     #[test]
     fn test_create_local_testnet_chain_spec() {
         local_testnet_config().build_storage().unwrap();
+    }
+
+    #[test]
+    #[cfg(feature = "with-staking")]
+    fn test_create_staking_local_chain_spec() {
+        local_staking_config().build_storage().unwrap();
     }
 
     #[test]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -57,6 +57,8 @@ impl SubstrateCli for Cli {
             "local" => Box::new(chain_spec::local_testnet_config()),
             "" | "main" => Box::new(chain_spec::main_config()),
             "arcadia" => Box::new(chain_spec::arcadia_config()),
+            #[cfg(feature = "with-staking")]
+            "staking-local" => Box::new(chain_spec::local_staking_config()),
             path => Box::new(chain_spec::ChainSpec::from_json_file(
                 std::path::PathBuf::from(path),
             )?),


### PR DESCRIPTION
In preparation of our staking specific testnet, this PR adds a new chain spec `staking-local`. That can be used to run a local staking enabled testnet. Usage:
1. Build a node via `cargo build --features with-staking`
2. Run one or two sample nodes with the flag `--chain staking-local`
