### PR TITLE
refactor: improve benchmark compile output

### DIFF
--- a/pallets/allocations/src/benchmarking.rs
+++ b/pallets/allocations/src/benchmarking.rs
@@ -16,17 +16,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//! Amendments pallet benchmarks
-
 #![cfg(feature = "runtime-benchmarks")]
+#![allow(unused)]
+
+//! Amendments pallet benchmarks
 
 use super::*;
 
-use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
+use crate::Pallet as Allocations;
+use frame_benchmarking::impl_benchmark_test_suite;
+use frame_benchmarking::{account, benchmarks};
 use frame_system::RawOrigin;
 use sp_std::prelude::*;
-
-use crate::Pallet as Allocations;
 
 const MAX_BYTES: u32 = 1_024;
 const SEED: u32 = 0;

--- a/pallets/allocations/src/lib.rs
+++ b/pallets/allocations/src/lib.rs
@@ -15,11 +15,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 #![cfg_attr(not(feature = "std"), no_std)]
-
+#[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
-
 #[cfg(test)]
 mod tests;
 

--- a/pallets/amendments/src/benchmarking.rs
+++ b/pallets/amendments/src/benchmarking.rs
@@ -19,6 +19,7 @@
 //! Amendments pallet benchmarks
 
 #![cfg(feature = "runtime-benchmarks")]
+#![allow(unused)]
 
 use super::*;
 

--- a/pallets/emergency-shutdown/src/benchmarking.rs
+++ b/pallets/emergency-shutdown/src/benchmarking.rs
@@ -19,6 +19,7 @@
 //! Reserve pallet benchmarks
 
 #![cfg(feature = "runtime-benchmarks")]
+#![allow(unused)]
 
 use super::*;
 

--- a/pallets/grants/src/benchmarking.rs
+++ b/pallets/grants/src/benchmarking.rs
@@ -17,16 +17,16 @@
  */
 
 #![cfg(feature = "runtime-benchmarks")]
+#![allow(unused)]
 
 use super::*;
 
+use crate::Pallet as Grants;
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_support::traits::{EnsureOrigin, UnfilteredDispatchable};
 use frame_system::RawOrigin;
 use sp_runtime::traits::Bounded;
 use sp_std::prelude::*;
-
-use crate::Pallet as Grants;
 
 const MAX_SCHEDULES: u32 = 100;
 const SEED: u32 = 0;

--- a/pallets/reserve/src/benchmarking.rs
+++ b/pallets/reserve/src/benchmarking.rs
@@ -19,6 +19,7 @@
 //! Reserve pallet benchmarks
 
 #![cfg(feature = "runtime-benchmarks")]
+#![allow(unused)]
 
 use super::*;
 
@@ -28,6 +29,7 @@ use frame_system::RawOrigin;
 use sp_runtime::traits::Saturating;
 use sp_std::prelude::*;
 
+#[cfg(test)]
 use crate::Pallet as Reserve;
 
 const SEED: u32 = 0;

--- a/pallets/root-of-trust/src/benchmarking.rs
+++ b/pallets/root-of-trust/src/benchmarking.rs
@@ -19,10 +19,12 @@
 //! Root Of Trust pallet benchmarks
 
 #![cfg(feature = "runtime-benchmarks")]
+#![allow(unused)]
 
 use super::*;
 
-use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
+use frame_benchmarking::impl_benchmark_test_suite;
+use frame_benchmarking::{account, benchmarks};
 use frame_system::RawOrigin;
 use sp_runtime::traits::Bounded;
 use sp_std::prelude::*;

--- a/pallets/staking/src/benchmarking.rs
+++ b/pallets/staking/src/benchmarking.rs
@@ -17,6 +17,7 @@
  */
 
 #![cfg(feature = "runtime-benchmarks")]
+#![allow(unused)]
 
 use super::*;
 

--- a/pallets/tcr/src/benchmarking.rs
+++ b/pallets/tcr/src/benchmarking.rs
@@ -19,10 +19,11 @@
 //! Tcr pallet benchmarks
 
 #![cfg(feature = "runtime-benchmarks")]
+#![allow(unused)]
 
 use super::*;
-
-use frame_benchmarking::{account, benchmarks_instance_pallet, impl_benchmark_test_suite};
+use frame_benchmarking::impl_benchmark_test_suite;
+use frame_benchmarking::{account, benchmarks_instance_pallet};
 use frame_support::pallet_prelude::DispatchResultWithPostInfo;
 use frame_system::RawOrigin;
 use sp_std::prelude::*;


### PR DESCRIPTION
Currently, several of our benchmarks output warnings concerning unused imports in addition to the benchmark data we requested. This is unaffected by the `--quiet` flag, and in at least one case, we may be compiling more dependency code than necessary.

This PR resolves the above issues through use of Rust compiler flags.