### PR TITLE
fix(ci): remove dead code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-cargo-build-target-
 
-    - name: Install ubuntu native dependencies
-      if: matrix.os == 'ubuntu-latest'
-      run: sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev
-
     - name: Run cargo-tarpaulin
       uses: actions-rs/tarpaulin@v0.1
       with:


### PR DESCRIPTION
Installing ubuntu native dependencies had become dead as of a previous process simplification. It turns out CI runs fine without it.