### PR TITLE
fix: runtime upgrade for pallet memberships

### DIFF
--- a/runtimes/main/src/lib.rs
+++ b/runtimes/main/src/lib.rs
@@ -339,21 +339,21 @@ mod collective_migration {
 pub struct MultiPalletMigration;
 impl OnRuntimeUpgrade for MultiPalletMigration {
     fn on_runtime_upgrade() -> frame_support::weights::Weight {
-        membership_migration::migrate();
-        collective_migration::migrate()
+        collective_migration::migrate();
+        membership_migration::migrate()
     }
 
     #[cfg(feature = "try-runtime")]
     fn pre_upgrade() -> Result<(), &'static str> {
-        membership_migration::pre_migrate();
         collective_migration::pre_migrate();
+        membership_migration::pre_migrate();
         Ok(())
     }
 
     #[cfg(feature = "try-runtime")]
     fn post_upgrade() -> Result<(), &'static str> {
-        membership_migration::post_migrate();
         collective_migration::post_migrate();
+        membership_migration::post_migrate();
         Ok(())
     }
 }

--- a/runtimes/main/src/lib.rs
+++ b/runtimes/main/src/lib.rs
@@ -174,11 +174,11 @@ pub struct MembershipPallets {
 
 pub fn get_membership_pallets_old_names() -> MembershipPallets {
     MembershipPallets {
-        technical: "Instance1",
-        validators: "Instance2",
-        financial: "Instance3",
-        root: "Instance4",
-        oracles: "Instance5",
+        technical: "Instance1Membership",
+        validators: "Instance2Membership",
+        financial: "Instance3Membership",
+        root: "Instance4Membership",
+        oracles: "Instance5Membership",
     }
 }
 

--- a/runtimes/main/src/lib.rs
+++ b/runtimes/main/src/lib.rs
@@ -377,6 +377,23 @@ mod grandpa_migration {
     }
 }
 
+pub fn make_committees_match_memberships() {
+    use frame_support::migration::put_storage_value;
+    put_storage_value(
+        b"TechnicalMembership",
+        b"Members",
+        &[],
+        TechnicalCommittee::members(),
+    );
+    put_storage_value(b"RootMembership", b"Members", &[], RootCommittee::members());
+    put_storage_value(
+        b"FinancialMembership",
+        b"Members",
+        &[],
+        FinancialCommittee::members(),
+    );
+}
+
 /// Migrate from `Instance1Membership` to the new pallet prefix `TechnicalMembership`
 pub struct MultiPalletMigration;
 impl OnRuntimeUpgrade for MultiPalletMigration {
@@ -385,7 +402,7 @@ impl OnRuntimeUpgrade for MultiPalletMigration {
         membership_migration::migrate();
         session_migration::migrate();
         grandpa_migration::migrate();
-
+        make_committees_match_memberships();
         <Runtime as frame_system::Config>::BlockWeights::get().max_block
     }
 

--- a/runtimes/main/src/lib.rs
+++ b/runtimes/main/src/lib.rs
@@ -364,7 +364,7 @@ mod grandpa_migration {
 
     #[cfg(feature = "try-runtime")]
     pub fn pre_migrate() {
-        pallet_grandpa::migrations::v4::pre_migrate::<Runtime, _>(pallet_name());
+        pallet_grandpa::migrations::v4::pre_migration::<Runtime, _>(pallet_name());
     }
 
     pub fn migrate() -> frame_support::weights::Weight {
@@ -373,7 +373,7 @@ mod grandpa_migration {
 
     #[cfg(feature = "try-runtime")]
     pub fn post_migrate() {
-        pallet_grandpa::migrations::v4::post_migrate::<Runtime, _>(pallet_name());
+        pallet_grandpa::migrations::v4::post_migration();
     }
 }
 

--- a/runtimes/main/src/lib.rs
+++ b/runtimes/main/src/lib.rs
@@ -161,125 +161,199 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPallets,
-    MembershipStoragePrefixMigration,
+    MultiPalletMigration,
 >;
 
-pub struct MembershipPallets {
-    technical: &'static str,
-    validators: &'static str,
-    financial: &'static str,
-    root: &'static str,
-    oracles: &'static str,
-}
+mod membership_migration {
+    use super::*;
 
-pub fn get_membership_pallets_old_names() -> MembershipPallets {
-    MembershipPallets {
-        technical: "Instance1Membership",
-        validators: "Instance2Membership",
-        financial: "Instance3Membership",
-        root: "Instance4Membership",
-        oracles: "Instance5Membership",
+    struct Pallets {
+        technical: &'static str,
+        validators: &'static str,
+        financial: &'static str,
+        root: &'static str,
+        oracles: &'static str,
     }
-}
 
-pub fn get_membership_pallets_new_names() -> MembershipPallets {
-    use frame_support::traits::PalletInfo;
-    MembershipPallets {
-        technical: <Runtime as frame_system::Config>::PalletInfo::name::<TechnicalMembership>()
-            .expect("TechnialMembership is part of runtime, so it has a name; qed"),
-        validators: <Runtime as frame_system::Config>::PalletInfo::name::<ValidatorsSet>()
-            .expect("ValidatorsSet is part of runtime, so it has a name; qed"),
-        financial: <Runtime as frame_system::Config>::PalletInfo::name::<FinancialMembership>()
-            .expect("FinancialMembership is part of runtime, so it has a name; qed"),
-        root: <Runtime as frame_system::Config>::PalletInfo::name::<RootMembership>()
-            .expect("RootMembership is part of runtime, so it has a name; qed"),
-        oracles: <Runtime as frame_system::Config>::PalletInfo::name::<AllocationsOracles>()
-            .expect("AllocationsOracles is part of runtime, so it has a name; qed"),
+    fn pallets_old_names() -> Pallets {
+        Pallets {
+            technical: "Instance1Membership",
+            validators: "Instance2Membership",
+            financial: "Instance3Membership",
+            root: "Instance4Membership",
+            oracles: "Instance5Membership",
+        }
     }
-}
 
-/// Migrate from `Instance1Membership` to the new pallet prefix `TechnicalMembership`
-pub struct MembershipStoragePrefixMigration;
-impl OnRuntimeUpgrade for MembershipStoragePrefixMigration {
-    fn on_runtime_upgrade() -> frame_support::weights::Weight {
-        let pallets_old_names = get_membership_pallets_old_names();
-        let pallets_new_names = get_membership_pallets_new_names();
+    fn pallets_new_names() -> Pallets {
+        use frame_support::traits::PalletInfo;
+        Pallets {
+            technical: <Runtime as frame_system::Config>::PalletInfo::name::<TechnicalMembership>()
+                .expect("TechnialMembership is part of runtime, so it has a name; qed"),
+            validators: <Runtime as frame_system::Config>::PalletInfo::name::<ValidatorsSet>()
+                .expect("ValidatorsSet is part of runtime, so it has a name; qed"),
+            financial: <Runtime as frame_system::Config>::PalletInfo::name::<FinancialMembership>()
+                .expect("FinancialMembership is part of runtime, so it has a name; qed"),
+            root: <Runtime as frame_system::Config>::PalletInfo::name::<RootMembership>()
+                .expect("RootMembership is part of runtime, so it has a name; qed"),
+            oracles: <Runtime as frame_system::Config>::PalletInfo::name::<AllocationsOracles>()
+                .expect("AllocationsOracles is part of runtime, so it has a name; qed"),
+        }
+    }
+
+    #[cfg(feature = "try-runtime")]
+    pub fn pre_migrate() {
+        let old_names = pallets_old_names();
+        let new_names = pallets_new_names();
+
+        pallet_membership::migrations::v4::pre_migrate::<TechnicalMembership, _>(
+            old_names.technical,
+            new_names.technical,
+        );
+        pallet_membership::migrations::v4::pre_migrate::<ValidatorsSet, _>(
+            old_names.validators,
+            new_names.validators,
+        );
+        pallet_membership::migrations::v4::pre_migrate::<FinancialMembership, _>(
+            old_names.financial,
+            new_names.financial,
+        );
+        pallet_membership::migrations::v4::pre_migrate::<RootMembership, _>(
+            old_names.root,
+            new_names.root,
+        );
+        pallet_membership::migrations::v4::pre_migrate::<AllocationsOracles, _>(
+            old_names.oracles,
+            new_names.oracles,
+        );
+    }
+
+    pub fn migrate() -> frame_support::weights::Weight {
+        let old_names = pallets_old_names();
+        let new_names = pallets_new_names();
 
         pallet_membership::migrations::v4::migrate::<Runtime, TechnicalMembership, _>(
-            pallets_old_names.technical,
-            pallets_new_names.technical,
+            old_names.technical,
+            new_names.technical,
         );
         pallet_membership::migrations::v4::migrate::<Runtime, ValidatorsSet, _>(
-            pallets_old_names.validators,
-            pallets_new_names.validators,
+            old_names.validators,
+            new_names.validators,
         );
         pallet_membership::migrations::v4::migrate::<Runtime, FinancialMembership, _>(
-            pallets_old_names.financial,
-            pallets_new_names.financial,
+            old_names.financial,
+            new_names.financial,
         );
         pallet_membership::migrations::v4::migrate::<Runtime, RootMembership, _>(
-            pallets_old_names.root,
-            pallets_new_names.root,
+            old_names.root,
+            new_names.root,
         );
         pallet_membership::migrations::v4::migrate::<Runtime, AllocationsOracles, _>(
-            pallets_old_names.oracles,
-            pallets_new_names.oracles,
+            old_names.oracles,
+            new_names.oracles,
         )
     }
 
     #[cfg(feature = "try-runtime")]
-    fn pre_upgrade() -> Result<(), &'static str> {
-        let pallets_old_names = get_membership_pallets_old_names();
-        let pallets_new_names = get_membership_pallets_new_names();
+    pub fn post_migrate() {
+        let old_names = pallets_old_names();
+        let new_names = pallets_new_names();
 
-        pallet_membership::migrations::v4::pre_migrate::<TechnicalMembership, _>(
-            pallets_old_names.technical,
-            pallets_new_names.technical,
+        pallet_membership::migrations::v4::post_migrate::<TechnicalMembership, _>(
+            old_names.technical,
+            new_names.technical,
         );
-        pallet_membership::migrations::v4::pre_migrate::<ValidatorsSet, _>(
-            pallets_old_names.validators,
-            pallets_new_names.validators,
+        pallet_membership::migrations::v4::post_migrate::<ValidatorsSet, _>(
+            old_names.validators,
+            new_names.validators,
         );
-        pallet_membership::migrations::v4::pre_migrate::<FinancialMembership, _>(
-            pallets_old_names.financial,
-            pallets_new_names.financial,
+        pallet_membership::migrations::v4::post_migrate::<FinancialMembership, _>(
+            old_names.financial,
+            new_names.financial,
         );
-        pallet_membership::migrations::v4::pre_migrate::<RootMembership, _>(
-            pallets_old_names.root,
-            pallets_new_names.root,
+        pallet_membership::migrations::v4::post_migrate::<RootMembership, _>(
+            old_names.root,
+            new_names.root,
         );
-        pallet_membership::migrations::v4::pre_migrate::<AllocationsOracles, _>(
-            pallets_old_names.oracles,
-            pallets_new_names.oracles,
+        pallet_membership::migrations::v4::post_migrate::<AllocationsOracles, _>(
+            old_names.oracles,
+            new_names.oracles,
         );
+    }
+}
+
+mod collective_migration {
+    use super::*;
+
+    struct Pallets {
+        technical: &'static str,
+        financial: &'static str,
+        root: &'static str,
+    }
+
+    fn pallets_old_names() -> Pallets {
+        Pallets {
+            technical: "Instance2Collective",
+            financial: "Instance3Collective",
+            root: "Instance4Collective",
+        }
+    }
+
+    #[cfg(feature = "try-runtime")]
+    pub fn pre_migrate() {
+        let old_names = pallets_old_names();
+        pallet_collective::migrations::v4::pre_migrate::<TechnicalCommittee, _>(
+            old_names.technical,
+        );
+        pallet_collective::migrations::v4::pre_migrate::<FinancialCommittee, _>(
+            old_names.financial,
+        );
+        pallet_collective::migrations::v4::pre_migrate::<RootCommittee, _>(old_names.root);
+    }
+
+    pub fn migrate() -> frame_support::weights::Weight {
+        let old_names = pallets_old_names();
+        pallet_collective::migrations::v4::migrate::<Runtime, TechnicalCommittee, _>(
+            old_names.technical,
+        );
+        pallet_collective::migrations::v4::migrate::<Runtime, FinancialCommittee, _>(
+            old_names.financial,
+        );
+        pallet_collective::migrations::v4::migrate::<Runtime, RootCommittee, _>(old_names.root)
+    }
+
+    #[cfg(feature = "try-runtime")]
+    pub fn post_migrate() {
+        let old_names = pallets_old_names();
+        pallet_collective::migrations::v4::post_migrate::<TechnicalCommittee, _>(
+            old_names.technical,
+        );
+        pallet_collective::migrations::v4::post_migrate::<FinancialCommittee, _>(
+            old_names.financial,
+        );
+        pallet_collective::migrations::v4::post_migrate::<RootCommittee, _>(old_names.root);
+    }
+}
+
+/// Migrate from `Instance1Membership` to the new pallet prefix `TechnicalMembership`
+pub struct MultiPalletMigration;
+impl OnRuntimeUpgrade for MultiPalletMigration {
+    fn on_runtime_upgrade() -> frame_support::weights::Weight {
+        membership_migration::migrate();
+        collective_migration::migrate()
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn pre_upgrade() -> Result<(), &'static str> {
+        membership_migration::pre_migrate();
+        collective_migration::pre_migrate();
         Ok(())
     }
 
     #[cfg(feature = "try-runtime")]
     fn post_upgrade() -> Result<(), &'static str> {
-        let pallets_old_names = get_membership_pallets_old_names();
-        let pallets_new_names = get_membership_pallets_new_names();
-
-        pallet_membership::migrations::v4::post_migrate::<TechnicalMembership, _>(
-            pallets_old_names.technical,
-            pallets_new_names.technical,
-        );
-        pallet_membership::migrations::v4::post_migrate::<ValidatorsSet, _>(
-            pallets_old_names.validators,
-            pallets_new_names.validators,
-        );
-        pallet_membership::migrations::v4::post_migrate::<FinancialMembership, _>(
-            pallets_old_names.financial,
-            pallets_new_names.financial,
-        );
-        pallet_membership::migrations::v4::post_migrate::<RootMembership, _>(
-            pallets_old_names.root,
-            pallets_new_names.root,
-        );
-        pallet_membership::migrations::v4::post_migrate::<AllocationsOracles, _>(
-            pallets_old_names.oracles,
-            pallets_new_names.oracles,
-        );
+        membership_migration::post_migrate();
+        collective_migration::post_migrate();
         Ok(())
     }
 }

--- a/runtimes/main/src/version.rs
+++ b/runtimes/main/src/version.rs
@@ -40,7 +40,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native
     /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     /// `spec_version` and `authoring_version` are the same between Wasm and native.
-    spec_version: 58,
+    spec_version: 59,
 
     /// Version of the implementation of the specification. Nodes are free to ignore this; it
     /// serves only as an indication that the code is different; as long as the other two versions


### PR DESCRIPTION
This is going to address the test net upgrade issue. We need to make sure that after we upgraded the test net and then our main-net, we actually remove this code as it's not checking for any versions now. 
Also as part of runtime migration we have addressed a discrepancy that was once lurked in the storage and had made come committees to have different members than their corresponding membership pallets. 

NOTE: This wouldn't pass the try-runtime test. We would need to merge it as it is. The reason being there are some known defects in the current storage which will be addressed by this PR itself (by overwriting to those storage prefixes)