### PR TITLE
send allocations as a balance transfer

### DIFF
--- a/pallets/allocations/src/tests.rs
+++ b/pallets/allocations/src/tests.rs
@@ -21,8 +21,7 @@
 use super::*;
 use crate::{self as pallet_allocations};
 use frame_support::{
-    assert_noop, assert_ok, ord_parameter_types, parameter_types,
-    weights::Pays, PalletId,
+    assert_noop, assert_ok, ord_parameter_types, parameter_types, weights::Pays, PalletId,
 };
 use frame_system::EnsureSignedBy;
 use sp_core::H256;

--- a/pallets/allocations/src/tests.rs
+++ b/pallets/allocations/src/tests.rs
@@ -22,7 +22,7 @@ use super::*;
 use crate::{self as pallet_allocations};
 use frame_support::{
     assert_noop, assert_ok, assert_storage_noop, ord_parameter_types, parameter_types,
-    weights::Pays,
+    weights::Pays, PalletId,
 };
 use frame_system::EnsureSignedBy;
 use sp_core::H256;
@@ -108,6 +108,7 @@ parameter_types! {
     pub const Receiver: u64 = 3;
     pub const CoinsLimit: u64 = 1_000_000;
     pub const Fee: Perbill = Perbill::from_percent(10);
+    pub const AllocPalletId: PalletId = PalletId(*b"py/alloc");
 }
 impl WithAccountId<u64> for Receiver {
     fn account_id() -> u64 {
@@ -117,6 +118,7 @@ impl WithAccountId<u64> for Receiver {
 impl Config for Test {
     type Event = ();
     type Currency = pallet_balances::Pallet<Self>;
+    type PalletId = AllocPalletId;
     type ProtocolFee = Fee;
     type ProtocolFeeReceiver = Receiver;
     type MaximumCoinsEverAllocated = CoinsLimit;

--- a/runtimes/eden/src/pallets_nodle.rs
+++ b/runtimes/eden/src/pallets_nodle.rs
@@ -19,7 +19,7 @@ use crate::{
     pallets_governance::MoreThanHalfOfTechComm, Allocations, Balances, CompanyReserve, Event,
     Runtime,
 };
-use frame_support::parameter_types;
+use frame_support::{parameter_types, PalletId};
 use primitives::Balance;
 use sp_runtime::Perbill;
 
@@ -32,11 +32,13 @@ impl pallet_emergency_shutdown::Config for Runtime {
 parameter_types! {
     pub const ProtocolFee: Perbill = Perbill::from_percent(20);
     pub const MaximumCoinsEverAllocated: Balance = 1_259_995_654_473_120_000_000;
+    pub const AllocPalletId: PalletId = PalletId(*b"py/alloc");
 }
 
 impl pallet_allocations::Config for Runtime {
     type Event = Event;
     type Currency = Balances;
+    type PalletId = PalletId;
     type ProtocolFee = ProtocolFee;
     type ProtocolFeeReceiver = CompanyReserve;
     type MaximumCoinsEverAllocated = MaximumCoinsEverAllocated;

--- a/runtimes/eden/src/pallets_nodle.rs
+++ b/runtimes/eden/src/pallets_nodle.rs
@@ -38,7 +38,7 @@ parameter_types! {
 impl pallet_allocations::Config for Runtime {
     type Event = Event;
     type Currency = Balances;
-    type PalletId = PalletId;
+    type PalletId = AllocPalletId;
     type ProtocolFee = ProtocolFee;
     type ProtocolFeeReceiver = CompanyReserve;
     type MaximumCoinsEverAllocated = MaximumCoinsEverAllocated;

--- a/runtimes/eden/src/version.rs
+++ b/runtimes/eden/src/version.rs
@@ -38,7 +38,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native
     /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     /// `spec_version` and `authoring_version` are the same between Wasm and native.
-    spec_version: 4,
+    spec_version: 5,
 
     /// Version of the implementation of the specification. Nodes are free to ignore this; it
     /// serves only as an indication that the code is different; as long as the other two versions

--- a/runtimes/main/src/pallets_nodle.rs
+++ b/runtimes/main/src/pallets_nodle.rs
@@ -23,7 +23,7 @@ use crate::{
     Allocations, Balances, CompanyReserve, Event, Runtime,
 };
 
-use frame_support::parameter_types;
+use frame_support::{parameter_types, PalletId};
 use primitives::{AccountId, Balance};
 use sp_core::u32_trait::{_1, _2};
 use sp_runtime::Perbill;
@@ -38,11 +38,13 @@ impl pallet_emergency_shutdown::Config for Runtime {
 parameter_types! {
     pub const ProtocolFee: Perbill = Perbill::from_percent(20);
     pub const MaximumCoinsEverAllocated: Balance = 1_259_995_654_473_120_000_000;
+    pub const AllocPalletId: PalletId = PalletId(*b"py/alloc");
 }
 
 impl pallet_allocations::Config for Runtime {
     type Event = Event;
     type Currency = Balances;
+    type PalletId = PalletId;
     type ProtocolFee = ProtocolFee;
     type ProtocolFeeReceiver = CompanyReserve;
     type MaximumCoinsEverAllocated = MaximumCoinsEverAllocated;

--- a/runtimes/main/src/pallets_nodle.rs
+++ b/runtimes/main/src/pallets_nodle.rs
@@ -44,7 +44,7 @@ parameter_types! {
 impl pallet_allocations::Config for Runtime {
     type Event = Event;
     type Currency = Balances;
-    type PalletId = PalletId;
+    type PalletId = AllocPalletId;
     type ProtocolFee = ProtocolFee;
     type ProtocolFeeReceiver = CompanyReserve;
     type MaximumCoinsEverAllocated = MaximumCoinsEverAllocated;

--- a/runtimes/main/src/version.rs
+++ b/runtimes/main/src/version.rs
@@ -40,7 +40,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native
     /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     /// `spec_version` and `authoring_version` are the same between Wasm and native.
-    spec_version: 60,
+    spec_version: 61,
 
     /// Version of the implementation of the specification. Nodes are free to ignore this; it
     /// serves only as an indication that the code is different; as long as the other two versions


### PR DESCRIPTION
Modify the way allocations are allocated to mint the coins to a special account before transfering them to the proper account. This will allow each and every allocation to show up in a `balances.Transfer` event from this same well known address (`4jbtsgNhpGAzdEGrKRb7g8Mq4ToNUpBVxeye942tWfG3gcYi`), thus making it possible for apps like Nodle Cash to fetch such events and correctly identify them as allocations on an API like Subscan.

Also modifies the way we verify the existential deposit requirements of each allocation to save on DB reads.