### PR TITLE
refactor constants

### DIFF
--- a/runtimes/eden/src/constants.rs
+++ b/runtimes/eden/src/constants.rs
@@ -30,14 +30,14 @@ use static_assertions::const_assert;
 
 /// Money matters.
 pub const NODL: Balance = 100_000_000_000;
-pub const DOLLARS: Balance = NODL / 100;
-pub const CENTS: Balance = DOLLARS / 100;
-pub const MILLICENTS: Balance = CENTS / 1_000;
+pub const MILLI_NODL: Balance = NODL / 1_000;
+pub const MICRO_NODL: Balance = MILLI_NODL / 1_000;
+pub const NANO_NODL: Balance = MICRO_NODL / 1_000;
 
-pub const EXISTENTIAL_DEPOSIT: Balance = 1 * MILLICENTS;
+pub const EXISTENTIAL_DEPOSIT: Balance = 100 * NANO_NODL;
 
 pub const fn deposit(items: u32, bytes: u32) -> Balance {
-    items as Balance * 15 * CENTS + (bytes as Balance) * 6 * CENTS
+    items as Balance * 1_500 * MICRO_NODL + (bytes as Balance) * 600 * MICRO_NODL
 }
 
 /// Time and blocks.
@@ -99,4 +99,20 @@ parameter_types! {
         })
         .avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
         .build_or_panic();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constants_did_not_change() {
+        const DOLLARS: Balance = NODL / 100; // = 10 MILLI
+        const CENTS: Balance = DOLLARS / 100; // = 100 MICRO
+        const MILLICENTS: Balance = CENTS / 1_000; // = 100 NANO
+
+        assert_eq!(10 * MILLI_NODL, DOLLARS);
+        assert_eq!(100 * MICRO_NODL, CENTS);
+        assert_eq!(100 * NANO_NODL, MILLICENTS);
+    }
 }

--- a/runtimes/eden/src/pallets_system.rs
+++ b/runtimes/eden/src/pallets_system.rs
@@ -102,7 +102,7 @@ impl pallet_balances::Config for Runtime {
 }
 
 parameter_types! {
-    pub const TransactionByteFee: Balance = 10 * constants::MILLICENTS;
+    pub const TransactionByteFee: Balance = 1 * constants::MICRO_NODL;
     pub const OperationalFeeMultiplier: u8 = 5;
     pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
     pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(1, 100_000);

--- a/runtimes/eden/src/version.rs
+++ b/runtimes/eden/src/version.rs
@@ -46,7 +46,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// do the same thing.
     /// Non-consensus-breaking optimizations are about the only changes that could be made which
     /// would result in only the `impl_version` changing.
-    impl_version: 0,
+    impl_version: 1,
 
     /// Used for hardware wallets. This typically happens when `SignedExtra` changes.
     transaction_version: 1,


### PR DESCRIPTION
Our previous constants naming for currency units was based on another codebase, most likely Substrate's template or Polkadot. It was confusing to say the least. This PR changes this creating new, more expressive, constants and replacing the old ones. A test was added to make sure my math is correct.