### PR TITLE
Consider quoting command expansion to prevent word splitting SH-2046

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,12 @@
+version = 1
+
+[[analyzers]]
+name = "rust"
+enabled = true
+
+  [analyzers.meta]
+  msrv = "1.30.0"
+
+[[analyzers]]
+name = "shell"
+enabled = true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.


### PR DESCRIPTION
DESCRIPTION
When command expansions are unquoted, word splitting and globbing will occur. This can result unintended behaviour filenames contain spaces.

Trying to fix it by adding quotes or escapes to the data will not work. Instead, quote the command substitution itself.

If the command substitution outputs multiple pieces of data, it is recommended use a loop instead.

Problematic code:
ls -l $(getfilename)
Preferred code:
# getfilename outputs 1 file
ls -l "$(getfilename)"

# getfilename outputs multiple files, linefeed separated
getfilename | while IFS='' read -r line
do
  ls -l "$line"
done
Exceptions:
In cases where you actually want word splitting, such as:

gcc $(pkg-config --libs openssl) client.c
This is because pkg-config outputs -lssl -lcrypto, which you want to break up by spaces into -lssl and -lcrypto.

A bash alternative in these cases is to use read -a for words or mapfile for lines. ksh can also use read -a, or a while read loop for lines. In this case, since pkg-config outputs words, you could use:

# Read words into an array in bash and ksh
read -ra args < <(pkg-config --libs openssl)

# expand args
gcc "${args[@]}" client.c