### PR TITLE
fix: reduce maximum weight of eden to .5 seconds

### DIFF
--- a/runtimes/eden/src/constants.rs
+++ b/runtimes/eden/src/constants.rs
@@ -64,8 +64,8 @@ pub const TARGET_BLOCK_FULLNESS: Perquintill = Perquintill::from_percent(25);
 /// We allow `Normal` extrinsics to fill up the block up to 75%, the rest can be used
 /// by  Operational  extrinsics.
 pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
-/// We allow for 2 seconds of compute with a 6 second average block time.
-pub const MAXIMUM_BLOCK_WEIGHT: Weight = 2 * WEIGHT_PER_SECOND;
+/// We allow for .5 seconds of compute with a 16 second average block time.
+pub const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND / 2;
 
 const_assert!(NORMAL_DISPATCH_RATIO.deconstruct() >= AVERAGE_ON_INITIALIZE_RATIO.deconstruct());
 

--- a/runtimes/eden/src/version.rs
+++ b/runtimes/eden/src/version.rs
@@ -38,7 +38,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native
     /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     /// `spec_version` and `authoring_version` are the same between Wasm and native.
-    spec_version: 5,
+    spec_version: 6,
 
     /// Version of the implementation of the specification. Nodes are free to ignore this; it
     /// serves only as an indication that the code is different; as long as the other two versions


### PR DESCRIPTION
The current version of the parachain assumes a maximum block weight of 2 seconds, however, the default for parachains is actually of .5 seconds (as used by Acala, Statemine, and others). This could explain the unstable block time on eden or paradis.