### PR TITLE
update eden chain and protocol ids

### DIFF
--- a/nodes/parachain/res/eden-testing.json
+++ b/nodes/parachain/res/eden-testing.json
@@ -1,6 +1,6 @@
 {
   "name": "Nodle Testing Parachain",
-  "id": "para_eden_testing",
+  "id": "para_eden_testing_0422",
   "chainType": "Live",
   "bootNodes": [
     "/dns4/node-6909510104162127872-0.p2p.onfinality.io/tcp/19254/p2p/12D3KooWNhD2ssau5szUX8xc4jXheNH6GjmJMqRFyd7gcjy9SYGW",
@@ -15,7 +15,7 @@
       0
     ]
   ],
-  "protocolId": "nodl-testing",
+  "protocolId": "nodl-testing-0422",
   "properties": {
     "tokenDecimals": 11,
     "tokenSymbol": "notNODL"


### PR DESCRIPTION
Update the IDs in the chain spec to clearly differentiate from the previous chain spec and avoid contamination of the collators.