### PR TITLE
technical review: fix weight computation

### DIFF
--- a/pallets/mandate/src/lib.rs
+++ b/pallets/mandate/src/lib.rs
@@ -52,7 +52,7 @@ pub mod pallet {
     #[pallet::call]
     impl<T: Config> Pallet<T> {
         /// Let the configured origin dispatch a call as root
-        #[pallet::weight(call.get_dispatch_info().weight + 10_000)]
+        #[pallet::weight(call.get_dispatch_info().weight.saturating_add(10_000))]
         pub fn apply(
             origin: OriginFor<T>,
             call: Box<<T as Config>::Call>,

--- a/pallets/reserve/src/lib.rs
+++ b/pallets/reserve/src/lib.rs
@@ -115,12 +115,13 @@ pub mod pallet {
         }
 
         /// Dispatch a call as coming from the reserve account
-        #[pallet::weight(
+        #[pallet::weight({
+            let dispatch_info = call.get_dispatch_info();
             (
-                call.get_dispatch_info().weight + 10_000,
-                call.get_dispatch_info().class,
+                dispatch_info.weight.saturating_add(10_000),
+                dispatch_info.class,
             )
-        )]
+        })]
         pub fn apply_as(
             origin: OriginFor<T>,
             call: Box<<T as Config<I>>::Call>,

--- a/runtimes/eden/src/version.rs
+++ b/runtimes/eden/src/version.rs
@@ -38,7 +38,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native
     /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     /// `spec_version` and `authoring_version` are the same between Wasm and native.
-    spec_version: 6,
+    spec_version: 7,
 
     /// Version of the implementation of the specification. Nodes are free to ignore this; it
     /// serves only as an indication that the code is different; as long as the other two versions

--- a/runtimes/main/src/version.rs
+++ b/runtimes/main/src/version.rs
@@ -40,7 +40,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     /// Version of the runtime specification. A full-node will not attempt to use its native
     /// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     /// `spec_version` and `authoring_version` are the same between Wasm and native.
-    spec_version: 61,
+    spec_version: 62,
 
     /// Version of the implementation of the specification. Nodes are free to ignore this; it
     /// serves only as an indication that the code is different; as long as the other two versions


### PR DESCRIPTION
SRLabs performed a technical review of our pallets and runtime. The weight functions in the `apply_as` and `apply` extrinsics is suffering from potential integer overflows and exponential complexity issues which could lead to badly computed weights/fees. This PR addresses this.
