### PR TITLE
cleanup actions

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -54,22 +54,10 @@ jobs:
       run: ./scripts/init.sh
 
     - name: Cargo build
-      run: cargo build --release
+      run: cargo build --release -p nodle-parachain
     
     - name: Archive Binary
       uses: actions/upload-artifact@v2
       with:
         name: nodle-parachain
         path: ./target/release/nodle-parachain
-
-    - name: Archive Binary
-      uses: actions/upload-artifact@v2
-      with:
-        name: nodle-main
-        path: ./target/release/nodle-main
-
-    - name: Archive Binary
-      uses: actions/upload-artifact@v2
-      with:
-        name: nodle-staking
-        path: ./target/release/nodle-staking

--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -59,5 +59,5 @@ jobs:
     - name: Archive Binary
       uses: actions/upload-artifact@v2
       with:
-        name: nodle-parachain
+        name: nodle-parachain-${{ matrix.os }}
         path: ./target/release/nodle-parachain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   target: wasm32-unknown-unknown
   tarpaulin-vers: '0.18.4'
   try-runtime-chain: dev
-  try-runtime-uri: wss://nodle.api.onfinality.io:443/public-ws
+  try-runtime-uri: wss://nodle-parachain.api.onfinality.io:443/public-ws
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       uses: actions-rs/tarpaulin@v0.1
       with:
         version: ${{ env.tarpaulin-vers }}
-        args: '--avoid-cfg-tarpaulin --all-features --workspace --timeout 120'
+        args: '--avoid-cfg-tarpaulin --all-features --workspace --timeout 120 --exclude runtimes-eden runtimes-main runtimes-staking nodle-chain nodle-parachain nodle-staking --exclude-files **/mock.rs **/weights.rs **/weights/*'
 
     - name: Upload to Codecov
       uses: codecov/codecov-action@v3.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       uses: actions-rs/tarpaulin@v0.1
       with:
         version: ${{ env.tarpaulin-vers }}
-        args: '--avoid-cfg-tarpaulin --verbose --all-features --timeout 120'
+        args: '--avoid-cfg-tarpaulin --verbose --all-features --bin nodle-parachain --timeout 120'
 
     - name: Upload to Codecov
       uses: codecov/codecov-action@v3.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,13 +84,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --features=try-runtime
+          args: --release --features=try-runtime -p nodle-parachain
 
       - name: Try Runtime
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --release --bin nodle-main --features=try-runtime try-runtime --execution native --chain ${{ env.try-runtime-chain }} on-runtime-upgrade live -u ${{ env.try-runtime-uri }}
+          args: --release --bin nodle-parachain --features=try-runtime try-runtime --execution native --chain ${{ env.try-runtime-chain }} on-runtime-upgrade live -u ${{ env.try-runtime-uri }}
 
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --release --bin nodle-parachain --features=try-runtime try-runtime --execution native --chain ${{ env.try-runtime-chain }} on-runtime-upgrade live -u ${{ env.try-runtime-uri }}
+          args: --release --workspace --features=try-runtime try-runtime --execution native --chain ${{ env.try-runtime-chain }} on-runtime-upgrade live -u ${{ env.try-runtime-uri }}
 
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       uses: actions-rs/tarpaulin@v0.1
       with:
         version: ${{ env.tarpaulin-vers }}
-        args: '--avoid-cfg-tarpaulin --verbose --all-features --bin nodle-parachain --timeout 120'
+        args: '--avoid-cfg-tarpaulin --all-features --bin nodle-parachain --timeout 120'
 
     - name: Upload to Codecov
       uses: codecov/codecov-action@v3.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       uses: actions-rs/tarpaulin@v0.1
       with:
         version: ${{ env.tarpaulin-vers }}
-        args: '--avoid-cfg-tarpaulin --all-features --bin nodle-parachain --timeout 120'
+        args: '--avoid-cfg-tarpaulin --all-features --workspace --timeout 120'
 
     - name: Upload to Codecov
       uses: codecov/codecov-action@v3.0.0
@@ -89,7 +89,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --release --workspace --features=try-runtime try-runtime --execution native --chain ${{ env.try-runtime-chain }} on-runtime-upgrade live -u ${{ env.try-runtime-uri }}
+          args: --release --bin nodle-parachain --features=try-runtime try-runtime --execution native --chain ${{ env.try-runtime-chain }} on-runtime-upgrade live -u ${{ env.try-runtime-uri }}
 
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,12 +79,6 @@ jobs:
           toolchain: ${{ env.nightly }}
           target: ${{ env.target }}
 
-      - name: Cargo build --features=try-runtime
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --features=try-runtime -p nodle-parachain
-
       - name: Try Runtime
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       uses: actions-rs/tarpaulin@v0.1
       with:
         version: ${{ env.tarpaulin-vers }}
-        args: '--avoid-cfg-tarpaulin --verbose --all-features --bin nodle-main --timeout 120'
+        args: '--avoid-cfg-tarpaulin --verbose --all-features --timeout 120'
 
     - name: Upload to Codecov
       uses: codecov/codecov-action@v3.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
   pull_request:
-  workflow_dispatch:
 
 env:
   nightly: nightly-2021-11-01


### PR DESCRIPTION
- [x] run CI tests/tarpaulin against the parachain node
- [x] run `try-runtime` against a parachain node and with a parachain runtime
- [x] reduce clutter when compiling binaries
- [x] ensure we have both ubuntu and mac os binaries