### PR TITLE
no need for roc chain spec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,6 @@ RUN mv /usr/share/ca* /tmp && \
 	chown -R nodle-chain:nodle-chain /nodle-chain/.local && \
 	ln -s /nodle-chain/.local/share/nodle-chain /data
 
-# rococo was rebooted and thus we need this custom spec for now
-RUN curl https://raw.githubusercontent.com/paritytech/polkadot/master/node/service/res/rococo.json > /rococo.json
-
 USER nodle-chain
 EXPOSE 30333 9933 9944
 VOLUME ["/data"]


### PR DESCRIPTION
We no longer need a custom rococo chain spec. Looks like it was updated within the latest polkadot release.