### PR TITLE
Remove without_storage_info for the amendments pallet

### DIFF
--- a/pallets/amendments/src/lib.rs
+++ b/pallets/amendments/src/lib.rs
@@ -82,14 +82,14 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// Schedule `amendment` to be executed after the configured time, unless vetoed by
 		/// `VetoOrigin`
-		#[pallet::weight(
-			 (
-				 T::WeightInfo::propose(
-					 amendment.using_encoded(|x| x.len()) as u32,
-				 ).saturating_add(amendment.get_dispatch_info().weight),
-				 DispatchClass::Operational,
-			 )
-		 )]
+		#[pallet::weight((
+			T::WeightInfo::propose(
+				amendment
+					.using_encoded(|x| x.len()) as u32)
+					.saturating_add(amendment.get_dispatch_info().weight),
+					DispatchClass::Operational,
+			)
+		)]
 		pub fn propose(origin: OriginFor<T>, amendment: Box<T::Amendment>) -> DispatchResultWithPostInfo {
 			T::SubmissionOrigin::try_origin(origin)
 				.map(|_| ())

--- a/pallets/amendments/src/lib.rs
+++ b/pallets/amendments/src/lib.rs
@@ -82,14 +82,14 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// Schedule `amendment` to be executed after the configured time, unless vetoed by
 		/// `VetoOrigin`
-		#[pallet::weight((
-			T::WeightInfo::propose(
-				amendment
-					.using_encoded(|x| x.len()) as u32)
-					.saturating_add(amendment.get_dispatch_info().weight),
-					DispatchClass::Operational,
+		#[pallet::weight(
+			(
+				T::WeightInfo::propose(
+					amendment.using_encoded(|x| x.len()) as u32,
+				).saturating_add(amendment.get_dispatch_info().weight),
+				DispatchClass::Operational,
 			)
-		)]
+		)]		
 		pub fn propose(origin: OriginFor<T>, amendment: Box<T::Amendment>) -> DispatchResultWithPostInfo {
 			T::SubmissionOrigin::try_origin(origin)
 				.map(|_| ())

--- a/pallets/amendments/src/lib.rs
+++ b/pallets/amendments/src/lib.rs
@@ -73,7 +73,6 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(PhantomData<T>);
 
 	#[pallet::hooks]
@@ -84,13 +83,13 @@ pub mod pallet {
 		/// Schedule `amendment` to be executed after the configured time, unless vetoed by
 		/// `VetoOrigin`
 		#[pallet::weight(
-			(
-				T::WeightInfo::propose(
-					amendment.using_encoded(|x| x.len()) as u32,
-				).saturating_add(amendment.get_dispatch_info().weight),
-				DispatchClass::Operational,
-			)
-		)]
+			 (
+				 T::WeightInfo::propose(
+					 amendment.using_encoded(|x| x.len()) as u32,
+				 ).saturating_add(amendment.get_dispatch_info().weight),
+				 DispatchClass::Operational,
+			 )
+		 )]
 		pub fn propose(origin: OriginFor<T>, amendment: Box<T::Amendment>) -> DispatchResultWithPostInfo {
 			T::SubmissionOrigin::try_origin(origin)
 				.map(|_| ())

--- a/pallets/amendments/src/lib.rs
+++ b/pallets/amendments/src/lib.rs
@@ -89,7 +89,7 @@ pub mod pallet {
 				).saturating_add(amendment.get_dispatch_info().weight),
 				DispatchClass::Operational,
 			)
-		)]		
+		)]
 		pub fn propose(origin: OriginFor<T>, amendment: Box<T::Amendment>) -> DispatchResultWithPostInfo {
 			T::SubmissionOrigin::try_origin(origin)
 				.map(|_| ())


### PR DESCRIPTION
Part of [#173](https://github.com/NodleCode/chain-workspace/issues/173)

**HighLights**

- Not much changes, removed `without_storage_info` from pallet