### PR TITLE
Remove without_storage_info for the mandate pallet

### DIFF
--- a/pallets/mandate/src/lib.rs
+++ b/pallets/mandate/src/lib.rs
@@ -47,7 +47,6 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(PhantomData<T>);
 
 	#[pallet::hooks]


### PR DESCRIPTION
Part of [#173](https://github.com/NodleCode/chain-workspace/issues/173)

**HighLights**

- Not much changes, removed `without_storage_info` from pallet