### PR TITLE
fix(runtime-eden): parachain's tx version should be higher than previous solo chain

### DIFF
--- a/runtimes/eden/src/version.rs
+++ b/runtimes/eden/src/version.rs
@@ -50,7 +50,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_version: 0,
 
 	/// Used for hardware wallets. This typically happens when `SignedExtra` changes.
-	transaction_version: 1,
+	transaction_version: 4,
 
 	apis: RUNTIME_API_VERSIONS,
 	state_version: 0,


### PR DESCRIPTION
Our previous solo main net's tx version was 3.55.0. This issue is raised by Zondax as Ledger Live would not allow an application's upgrade for Nodle on Ledger otherwise.