### PR TITLE
Silence a few clippy warnings

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#![allow(clippy::derive_partial_eq_without_eq)]
 
 use cumulus_primitives_core::ParaId;
 use primitives::{AccountId, Balance, Signature};
@@ -39,7 +40,7 @@ pub fn get_public_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pa
 }
 
 /// The extensions for the [`ChainSpec`].
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ChainSpecGroup, ChainSpecExtension)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ChainSpecGroup, ChainSpecExtension)]
 #[serde(rename_all = "camelCase")]
 pub struct Extensions {
 	/// The relay chain of the Parachain.

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -61,6 +61,7 @@ type HostFunctions = (
 ///
 /// Use this macro if you don't actually need the full service, but just the builder in order to
 /// be able to perform chain operations.
+#[allow(clippy::type_complexity)]
 pub fn new_partial<RuntimeApi, BIQ>(
 	config: &Configuration,
 	build_import_queue: BIQ,
@@ -357,6 +358,7 @@ where
 }
 
 /// Build the import queue for the rococo parachain runtime.
+#[allow(clippy::type_complexity)]
 pub fn parachain_build_import_queue(
 	client: Arc<TFullClient<Block, runtime_eden::RuntimeApi, WasmExecutor<HostFunctions>>>,
 	config: &Configuration,

--- a/pallets/mandate/src/lib.rs
+++ b/pallets/mandate/src/lib.rs
@@ -52,6 +52,7 @@ pub mod pallet {
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
 
+	#[allow(clippy::boxed_local)]
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Let the configured origin dispatch a call as root

--- a/pallets/reserve/src/lib.rs
+++ b/pallets/reserve/src/lib.rs
@@ -96,6 +96,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[allow(clippy::boxed_local)]
 		/// Dispatch a call as coming from the reserve account
 		#[pallet::weight({
             let dispatch_info = call.get_dispatch_info();

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -1265,6 +1265,7 @@ pub mod pallet {
 	#[pallet::getter(fn bonded_sessions)]
 	pub(crate) type BondedSessions<T: Config> = StorageValue<_, Vec<SessionIndex>, ValueQuery>;
 
+	#[allow(clippy::type_complexity)]
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
 		pub stakers: Vec<(T::AccountId, Option<T::AccountId>, BalanceOf<T>)>,

--- a/runtimes/eden/src/pallets_system.rs
+++ b/runtimes/eden/src/pallets_system.rs
@@ -102,7 +102,7 @@ impl pallet_balances::Config for Runtime {
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = 1 * constants::MICRO_NODL;
+	pub const TransactionByteFee: Balance = constants::MICRO_NODL;
 	pub const OperationalFeeMultiplier: u8 = 5;
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
 	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(1, 100_000);

--- a/runtimes/eden/src/pallets_system.rs
+++ b/runtimes/eden/src/pallets_system.rs
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#![allow(clippy::identity_op)]
+
 use crate::{
 	constants, implementations::DealWithFees, version::VERSION, Balances, Call, CompanyReserve, Event, Origin,
 	PalletInfo, Runtime, SignedExtra, SignedPayload, System, UncheckedExtrinsic,
@@ -102,7 +104,7 @@ impl pallet_balances::Config for Runtime {
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = constants::MICRO_NODL;
+	pub const TransactionByteFee: Balance = 1 * constants::MICRO_NODL;
 	pub const OperationalFeeMultiplier: u8 = 5;
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
 	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(1, 100_000);

--- a/runtimes/eden/src/pallets_util.rs
+++ b/runtimes/eden/src/pallets_util.rs
@@ -105,7 +105,7 @@ parameter_types! {
 	pub const ClassDeposit: Balance = 10 * constants::NODL;
 	pub const InstanceDeposit: Balance = 100 * constants::MILLI_NODL;
 	pub const MetadataDepositBase: Balance = 10 * constants::NODL;
-	pub const MetadataDepositPerByte: Balance = 1 * constants::NODL;
+	pub const MetadataDepositPerByte: Balance = constants::NODL;
 	pub const KeyLimit: u32 = 32;
 	pub const ValueLimit: u32 = 256;
 	pub const StringLimit: u32 = 50;

--- a/runtimes/eden/src/pallets_util.rs
+++ b/runtimes/eden/src/pallets_util.rs
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#![allow(clippy::identity_op)]
+
 use crate::{
 	constants, implementations::RelayChainBlockNumberProvider, pallets_governance::MoreThanHalfOfTechComm, Balances,
 	Call, Event, Origin, OriginCaller, Preimage, Runtime,
@@ -91,6 +93,7 @@ parameter_types! {
 	pub const PreimageByteDeposit: Balance = constants::deposit(0, 1);
 }
 
+#[allow(clippy::identity_op)]
 impl pallet_preimage::Config for Runtime {
 	type WeightInfo = pallet_preimage::weights::SubstrateWeight<Runtime>;
 	type Event = Event;
@@ -105,7 +108,7 @@ parameter_types! {
 	pub const ClassDeposit: Balance = 10 * constants::NODL;
 	pub const InstanceDeposit: Balance = 100 * constants::MILLI_NODL;
 	pub const MetadataDepositBase: Balance = 10 * constants::NODL;
-	pub const MetadataDepositPerByte: Balance = constants::NODL;
+	pub const MetadataDepositPerByte: Balance = 1 * constants::NODL;
 	pub const KeyLimit: u32 = 32;
 	pub const ValueLimit: u32 = 256;
 	pub const StringLimit: u32 = 50;


### PR DESCRIPTION
Should make the build clean.

Removed `1 * something`  it existed only for consistency with other values in the lists

`derive_partial_eq_without_eq` implemented suggestion but another source was included in the same file so I also silenced it

`#[allow(clippy::type_complexity)]` yes the types are complex let's just acknowledge that

`#[allow(clippy::boxed_local)]` not sure if we should change the code or silence the warning so I silenced it.