### PR TITLE
Remove without_storage_info for the allocations pallet V2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 env:
   nightly: nightly
   target: wasm32-unknown-unknown
-  tarpaulin-vers: '0.20.0'
+  tarpaulin-vers: "0.20.0"
   try-runtime-chain: dev
   try-runtime-uri: wss://nodle-parachain.api.onfinality.io:443/public-ws
 
@@ -18,62 +18,63 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: ${{ env.nightly }}
-        override: true
-        target: ${{ env.target }}
-        components: rustfmt,clippy
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.nightly }}
+          override: true
+          target: ${{ env.target }}
+          components: rustfmt,clippy
 
-    - name: Cache cargo registry
-      uses: actions/cache@v2.1.7
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-registry-
+      - name: Cache cargo registry
+        uses: actions/cache@v2.1.7
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
 
-    - name: Cache cargo index
-      uses: actions/cache@v2.1.7
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-index-
+      - name: Cache cargo index
+        uses: actions/cache@v2.1.7
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-index-
 
-    - name: Cache cargo build
-      uses: actions/cache@v2.1.7
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-build-target-
-    
-    - name: Fmt
-      uses: actions-rs/cargo@v1
-      with:
-        toolchain: ${{ env.nightly }}
-        command: fmt
+      - name: Cache cargo build
+        uses: actions/cache@v2.1.7
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-target-
 
-    - name: Clippy
-      uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all-features -- -A clippy::type_complexity -A clippy::identity_op -A clippy::boxed_local -D dead_code
-        toolchain: ${{ env.nightly }}
+      - name: Fmt
+        uses: actions-rs/cargo@v1
+        with:
+          toolchain: ${{ env.nightly }}
+          command: fmt
 
-    - name: Run cargo-tarpaulin
-      uses: actions-rs/tarpaulin@v0.1
-      with:
-        version: ${{ env.tarpaulin-vers }}
-        args: '--avoid-cfg-tarpaulin --all-features --workspace --timeout 120 --exclude runtimes-eden runtimes-main runtimes-staking nodle-chain nodle-parachain nodle-staking --exclude-files **/mock.rs **/weights.rs **/weights/*'
+      - name: Clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features -- -A clippy::type_complexity -A clippy::identity_op -A clippy::boxed_local -D dead_code
+          toolchain: ${{ env.nightly }}
 
-    - name: Upload to Codecov
-      uses: codecov/codecov-action@v3.0.0
-      with:
-        fail_ci_if_error: true
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
+        with:
+          version: ${{ env.tarpaulin-vers }}
+          args: "--avoid-cfg-tarpaulin --all-features --workspace --timeout 120 --exclude runtimes-eden runtimes-main runtimes-staking nodle-chain nodle-parachain nodle-staking --exclude-files **/mock.rs **/weights.rs **/weights/*"
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v3.0.0
+        with:
+          fail_ci_if_error: true
+
 
   try-runtime:
     runs-on: ubuntu-latest
@@ -85,6 +86,7 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
+          target: ${{ env.target }}
 
       - name: Install Rust nightly
         uses: actions-rs/toolchain@v1
@@ -92,6 +94,7 @@ jobs:
           profile: minimal
           toolchain: ${{ env.nightly }}
           target: ${{ env.target }}
+          default: true
 
       - name: Try Runtime
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5199,7 +5199,9 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log",
  "pallet-balances",
+ "pallet-membership",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -5207,6 +5209,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "sp-tracing",
  "support",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4931,7 +4931,7 @@ dependencies = [
 
 [[package]]
 name = "nodle-parachain"
-version = "2.0.20"
+version = "2.0.21"
 dependencies = [
  "clap",
  "cumulus-client-cli",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-allocations"
-version = "2.0.20"
+version = "2.0.21"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5580,7 +5580,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-grants"
-version = "2.0.20"
+version = "2.0.21"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-mandate"
-version = "2.0.20"
+version = "2.0.21"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5822,7 +5822,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-poa"
-version = "2.0.20"
+version = "2.0.21"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5898,7 +5898,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-reserve"
-version = "2.0.20"
+version = "2.0.21"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "2.0.20"
+version = "2.0.21"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7809,7 +7809,7 @@ dependencies = [
 
 [[package]]
 name = "primitives"
-version = "2.0.20"
+version = "2.0.21"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8403,7 +8403,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-eden"
-version = "2.0.20"
+version = "2.0.21"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -11043,7 +11043,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "support"
-version = "2.0.20"
+version = "2.0.21"
 
 [[package]]
 name = "syn"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Nodle <support@nodle.com>", "Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"
 name = "nodle-parachain"
-version = "2.0.20"
+version = "2.0.21"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,20 +1,20 @@
 /*
-* This file is part of the Nodle Chain distributed at https://github.com/NodleCode/chain
-* Copyright (C) 2020-2022  Nodle International
-*
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ * This file is part of the Nodle Chain distributed at https://github.com/NodleCode/chain
+ * Copyright (C) 2020-2022  Nodle International
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 // clippy complains about ChainSpecGroup which we cannot modify
 #![allow(clippy::derive_partial_eq_without_eq)]

--- a/pallets/allocations/Cargo.toml
+++ b/pallets/allocations/Cargo.toml
@@ -13,6 +13,7 @@ std = [
   "frame-support/std",
   "frame-system/std",
   "pallet-balances/std",
+  "pallet-membership/std",
   "sp-io/std",
   "sp-runtime/std",
   "sp-std/std",
@@ -22,9 +23,11 @@ runtime-benchmarks = [
   "frame-system/runtime-benchmarks",
   "frame-support/runtime-benchmarks",
 ]
+try-runtime = ["frame-support/try-runtime"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive",] }
+log = { version = "0.4.14", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 scale-info = { version = "2.0.1", default-features = false, features = [  "derive",] }
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.20" }
@@ -37,4 +40,6 @@ sp-std = { git = "https://github.com/paritytech/substrate", default-features = f
 support = { path = "../../support" }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.20" }
+sp-tracing = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.20" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.20" }
+pallet-membership = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.20" }

--- a/pallets/allocations/Cargo.toml
+++ b/pallets/allocations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-allocations"
-version = "2.0.20"
+version = "2.0.21"
 authors = ['Eliott Teissonniere <git.eliott@teissonniere.org>']
 edition = "2021"
 description = "A pallet to handle the Proof Of Connectivity allocations rewards"

--- a/pallets/allocations/src/benchmarking.rs
+++ b/pallets/allocations/src/benchmarking.rs
@@ -42,9 +42,9 @@ fn make_benchmark_config<T: Config>() -> BenchmarkConfig<T> {
 	let grantee: T::AccountId = account("grantee", 0, SEED);
 	let oracle: T::AccountId = account("oracle", 0, SEED);
 
-	let mut members = <ValidatorSet<T>>::get();
+	let mut members = <BenchmarkOracles<T>>::get();
 	assert!(members.try_push(oracle.clone()).is_ok());
-	<ValidatorSet<T>>::put(&members);
+	<BenchmarkOracles<T>>::put(&members);
 
 	BenchmarkConfig { grantee, oracle }
 }

--- a/pallets/allocations/src/benchmarking.rs
+++ b/pallets/allocations/src/benchmarking.rs
@@ -21,11 +21,15 @@
 //! Amendments pallet benchmarks
 
 use super::*;
+use crate::BalanceOf;
+#[cfg(test)]
 use crate::Pallet as Allocations;
 use frame_benchmarking::{account, benchmarks};
-use frame_support::BoundedVec;
+use frame_support::{traits::ConstU32, BoundedVec};
 use frame_system::RawOrigin;
 use sp_std::prelude::*;
+
+pub type MaxMembers = ConstU32<10>;
 
 const SEED: u32 = 0;
 
@@ -35,13 +39,16 @@ pub struct BenchmarkConfig<T: Config> {
 }
 
 fn make_benchmark_config<T: Config>() -> BenchmarkConfig<T> {
-	let grantee = account("grantee", 0, SEED);
-	let oracle = account("oracle", 0, SEED);
+	let grantee: T::AccountId = account("grantee", 0, SEED);
+	let oracle: T::AccountId = account("oracle", 0, SEED);
+
+	let mut members = <ValidatorSet<T>>::get();
+	assert!(members.try_push(oracle.clone()).is_ok());
+	<ValidatorSet<T>>::put(&members);
 
 	BenchmarkConfig { grantee, oracle }
 }
 
-type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 fn make_batch<T: Config>(b: u32) -> BoundedVec<(T::AccountId, BalanceOf<T>), T::MaxAllocs> {
 	let mut ret = BoundedVec::with_bounded_capacity(b as usize);
 
@@ -55,8 +62,6 @@ fn make_batch<T: Config>(b: u32) -> BoundedVec<(T::AccountId, BalanceOf<T>), T::
 benchmarks! {
 	allocate {
 		let config = make_benchmark_config::<T>();
-
-		Pallet::<T>::initialize_members(&[config.oracle.clone()]);
 	}: _(RawOrigin::Signed(config.oracle.clone()), config.grantee.clone(), T::ExistentialDeposit::get() * 10u32.into(), vec![])
 
 	batch {
@@ -65,7 +70,6 @@ benchmarks! {
 		let config = make_benchmark_config::<T>();
 		let batch_arg = make_batch::<T>(b);
 
-		Pallet::<T>::initialize_members(&[config.oracle.clone()]);
 	}: _(RawOrigin::Signed(config.oracle.clone()), batch_arg)
 
 	impl_benchmark_test_suite!(

--- a/pallets/allocations/src/lib.rs
+++ b/pallets/allocations/src/lib.rs
@@ -228,14 +228,9 @@ pub mod pallet {
 impl<T: Config> Pallet<T> {
 	pub fn is_oracle(who: T::AccountId) -> bool {
 		#[cfg(feature = "runtime-benchmarks")]
-		if <ValidatorSet<T>>::get().is_empty() {
-			T::OracleMembers::contains(&who)
-		} else {
-			Self::contains(&who)
-		}
-
+		return T::OracleMembers::contains(&who) || Self::benchmark_oracles().contains(&who);
 		#[cfg(not(feature = "runtime-benchmarks"))]
-		T::OracleMembers::contains(&who)
+		return T::OracleMembers::contains(&who);
 	}
 
 	fn ensure_oracle(origin: T::Origin) -> DispatchResult {

--- a/pallets/allocations/src/lib.rs
+++ b/pallets/allocations/src/lib.rs
@@ -229,7 +229,7 @@ impl<T: Config> Pallet<T> {
 	pub fn is_oracle(who: T::AccountId) -> bool {
 		#[cfg(feature = "runtime-benchmarks")]
 		if <ValidatorSet<T>>::get().is_empty() {
-			return T::OracleMembers::contains(&who);
+			T::OracleMembers::contains(&who)
 		} else {
 			return Self::contains(&who);
 		}

--- a/pallets/allocations/src/lib.rs
+++ b/pallets/allocations/src/lib.rs
@@ -231,7 +231,7 @@ impl<T: Config> Pallet<T> {
 		if <ValidatorSet<T>>::get().is_empty() {
 			T::OracleMembers::contains(&who)
 		} else {
-			return Self::contains(&who);
+			Self::contains(&who)
 		}
 
 		#[cfg(not(feature = "runtime-benchmarks"))]

--- a/pallets/allocations/src/lib.rs
+++ b/pallets/allocations/src/lib.rs
@@ -16,26 +16,32 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #![cfg_attr(not(feature = "std"), no_std)]
+
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
+
 #[cfg(test)]
 mod tests;
 
+mod migrations;
+
+use codec::{Decode, Encode};
 use frame_support::{
-	dispatch::Weight,
 	ensure,
-	migration::remove_storage_prefix,
-	traits::{tokens::ExistenceRequirement, ChangeMembers, Currency, Get, InitializeMembers},
-	transactional, PalletId,
+	pallet_prelude::MaxEncodedLen,
+	traits::{tokens::ExistenceRequirement, Contains, Currency, Get},
+	transactional, BoundedVec, PalletId,
 };
+
 use frame_system::ensure_signed;
+use scale_info::TypeInfo;
+use sp_runtime::traits::AccountIdConversion;
+use sp_runtime::{
+	traits::{CheckedAdd, Saturating, Zero},
+	DispatchResult, Perbill, RuntimeDebug,
+};
 use sp_std::prelude::*;
 use support::WithAccountId;
-
-use sp_runtime::{
-	traits::{AccountIdConversion, CheckedAdd, Saturating, Zero},
-	DispatchResult, Perbill,
-};
 
 pub mod weights;
 pub use weights::WeightInfo;
@@ -44,10 +50,26 @@ pub use pallet::*;
 
 type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
+// A value placed in storage that represents the current version of the Allocations storage.
+// This value is used by the `on_runtime_upgrade` logic to determine whether we run storage
+// migration logic. This should match directly with the semantic versions of the Rust crate.
+#[derive(Encode, Decode, MaxEncodedLen, Clone, Copy, PartialEq, Eq, RuntimeDebug, TypeInfo)]
+enum Releases {
+	V0_0_0Legacy, // To handle Legacy version
+	V2_0_21,
+}
+
+impl Default for Releases {
+	fn default() -> Self {
+		Releases::V0_0_0Legacy
+	}
+}
+
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
 	use frame_support::pallet_prelude::*;
+	use frame_support::traits::OnRuntimeUpgrade;
 	use frame_system::pallet_prelude::*;
 
 	#[pallet::config]
@@ -71,20 +93,30 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxAllocs: Get<u32>;
 
+		type OracleMembers: Contains<Self::AccountId>;
+
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
 	}
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(PhantomData<T>);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		fn on_runtime_upgrade() -> Weight {
-			remove_storage_prefix(<Pallet<T>>::name().as_bytes(), b"CoinsConsumed", b"");
-			T::DbWeight::get().writes(1)
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<(), &'static str> {
+			migrations::v1::MigrateToBoundedOracles::<T>::pre_upgrade()
+		}
+
+		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+			migrations::v1::MigrateToBoundedOracles::<T>::on_runtime_upgrade()
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade() -> Result<(), &'static str> {
+			migrations::v1::MigrateToBoundedOracles::<T>::post_upgrade()
 		}
 	}
 
@@ -152,8 +184,8 @@ pub mod pallet {
 		/// Can only be called by an oracle, trigger a token mint and dispatch to
 		/// `amount`, minus protocol fees
 		#[pallet::weight(
-			<T as pallet::Config>::WeightInfo::allocate()
-		)]
+			 <T as pallet::Config>::WeightInfo::allocate()
+		 )]
 		// we add the `transactional` modifier here in the event that one of the
 		// transfers fail. the code itself should already prevent this but we add
 		// this as an additional guarantee.
@@ -185,13 +217,25 @@ pub mod pallet {
 	}
 
 	#[pallet::storage]
-	#[pallet::getter(fn oracles)]
-	pub type Oracles<T: Config> = StorageValue<_, Vec<T::AccountId>, ValueQuery>;
+	pub(crate) type StorageVersion<T: Config> = StorageValue<_, Releases, ValueQuery>;
+
+	#[cfg(feature = "runtime-benchmarks")]
+	#[pallet::storage]
+	#[pallet::getter(fn validator_set)]
+	pub type ValidatorSet<T: Config> = StorageValue<_, BoundedVec<T::AccountId, benchmarking::MaxMembers>, ValueQuery>;
 }
 
 impl<T: Config> Pallet<T> {
 	pub fn is_oracle(who: T::AccountId) -> bool {
-		Self::oracles().contains(&who)
+		#[cfg(feature = "runtime-benchmarks")]
+		if <ValidatorSet<T>>::get().is_empty() {
+			return T::OracleMembers::contains(&who);
+		} else {
+			return Self::contains(&who);
+		}
+
+		#[cfg(not(feature = "runtime-benchmarks"))]
+		return T::OracleMembers::contains(&who);
 	}
 
 	fn ensure_oracle(origin: T::Origin) -> DispatchResult {
@@ -201,14 +245,9 @@ impl<T: Config> Pallet<T> {
 	}
 }
 
-impl<T: Config> ChangeMembers<T::AccountId> for Pallet<T> {
-	fn change_members_sorted(_incoming: &[T::AccountId], _outgoing: &[T::AccountId], new: &[T::AccountId]) {
-		<Oracles<T>>::put(new);
-	}
-}
-
-impl<T: Config> InitializeMembers<T::AccountId> for Pallet<T> {
-	fn initialize_members(init: &[T::AccountId]) {
-		<Oracles<T>>::put(init);
+#[cfg(feature = "runtime-benchmarks")]
+impl<T: Config> Contains<T::AccountId> for Pallet<T> {
+	fn contains(t: &T::AccountId) -> bool {
+		Self::validator_set().binary_search(t).is_ok()
 	}
 }

--- a/pallets/allocations/src/lib.rs
+++ b/pallets/allocations/src/lib.rs
@@ -221,8 +221,8 @@ pub mod pallet {
 
 	#[cfg(feature = "runtime-benchmarks")]
 	#[pallet::storage]
-	#[pallet::getter(fn validator_set)]
-	pub type ValidatorSet<T: Config> = StorageValue<_, BoundedVec<T::AccountId, benchmarking::MaxMembers>, ValueQuery>;
+	#[pallet::getter(fn benchmark_oracles)]
+	pub type BenchmarkOracles<T: Config> = StorageValue<_, BoundedVec<T::AccountId, benchmarking::MaxMembers>, ValueQuery>;
 }
 
 impl<T: Config> Pallet<T> {

--- a/pallets/allocations/src/lib.rs
+++ b/pallets/allocations/src/lib.rs
@@ -222,7 +222,8 @@ pub mod pallet {
 	#[cfg(feature = "runtime-benchmarks")]
 	#[pallet::storage]
 	#[pallet::getter(fn benchmark_oracles)]
-	pub type BenchmarkOracles<T: Config> = StorageValue<_, BoundedVec<T::AccountId, benchmarking::MaxMembers>, ValueQuery>;
+	pub type BenchmarkOracles<T: Config> =
+		StorageValue<_, BoundedVec<T::AccountId, benchmarking::MaxMembers>, ValueQuery>;
 }
 
 impl<T: Config> Pallet<T> {
@@ -237,12 +238,5 @@ impl<T: Config> Pallet<T> {
 		let sender = ensure_signed(origin)?;
 		ensure!(Self::is_oracle(sender), Error::<T>::OracleAccessDenied);
 		Ok(())
-	}
-}
-
-#[cfg(feature = "runtime-benchmarks")]
-impl<T: Config> Contains<T::AccountId> for Pallet<T> {
-	fn contains(t: &T::AccountId) -> bool {
-		Self::validator_set().binary_search(t).is_ok()
 	}
 }

--- a/pallets/allocations/src/lib.rs
+++ b/pallets/allocations/src/lib.rs
@@ -235,7 +235,7 @@ impl<T: Config> Pallet<T> {
 		}
 
 		#[cfg(not(feature = "runtime-benchmarks"))]
-		return T::OracleMembers::contains(&who);
+		T::OracleMembers::contains(&who)
 	}
 
 	fn ensure_oracle(origin: T::Origin) -> DispatchResult {

--- a/pallets/allocations/src/migrations.rs
+++ b/pallets/allocations/src/migrations.rs
@@ -1,0 +1,145 @@
+/*
+ * This file is part of the Nodle Chain distributed at https://github.com/NodleCode/chain
+ * Copyright (C) 2020-2022  Nodle International
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pub mod v1 {
+	use crate::{Config, Releases, StorageVersion};
+
+	#[cfg(feature = "try-runtime")]
+	use crate::BalanceOf;
+
+	use frame_support::{
+		pallet_prelude::PhantomData,
+		storage::migration::{have_storage_value, remove_storage_prefix},
+		traits::{Get, OnRuntimeUpgrade},
+		weights::Weight,
+	};
+
+	pub struct MigrateToBoundedOracles<T>(PhantomData<T>);
+	impl<T: Config> OnRuntimeUpgrade for MigrateToBoundedOracles<T> {
+		fn on_runtime_upgrade() -> Weight {
+			log::info!(
+				"on_runtime_upgrade[{:#?}]=> Running migration with current storage version {:?} / onchain {:?}",
+				line!(),
+				crate::Releases::V2_0_21,
+				<StorageVersion<T>>::get(),
+			);
+
+			if <StorageVersion<T>>::get() == Releases::V0_0_0Legacy {
+				let pallet_prefix: &[u8] = b"Allocations";
+				let storage_item1_prefix: &[u8] = b"Oracles";
+				let storage_item2_prefix: &[u8] = b"CoinsConsumed";
+
+				if have_storage_value(pallet_prefix, storage_item1_prefix, &[])
+					&& have_storage_value(pallet_prefix, storage_item2_prefix, &[])
+				{
+					remove_storage_prefix(pallet_prefix, storage_item1_prefix, &[]);
+					remove_storage_prefix(pallet_prefix, storage_item2_prefix, &[]);
+
+					<StorageVersion<T>>::put(crate::Releases::V2_0_21);
+
+					log::info!(
+						"on_runtime_upgrade[{:#?}]=> Removed Oracles & CoinsConsumed, Migrated to storage version {:?}",
+						line!(),
+						<StorageVersion<T>>::get()
+					);
+				} else {
+					panic!(
+						"on_runtime_upgrade[{:#?}]=> Oracles & CoinsConsumed doesn't exist",
+						line!()
+					);
+				}
+
+				T::DbWeight::get().reads_writes(2, 2)
+			} else {
+				log::info!(
+					"on_runtime_upgrade[{:#?}]=> Migration did not executed. This probably should be removed",
+					line!(),
+				);
+				T::DbWeight::get().reads(1)
+			}
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<(), &'static str> {
+			use frame_support::storage::migration::get_storage_value;
+
+			log::info!(
+				"pre_upgrade[{:#?}]=> with current storage version {:?} / onchain {:?}",
+				line!(),
+				crate::Releases::V2_0_21,
+				<StorageVersion<T>>::get(),
+			);
+
+			if <StorageVersion<T>>::get() == Releases::V0_0_0Legacy {
+				let pallet_prefix: &[u8] = b"Allocations";
+				let storage_item1_prefix: &[u8] = b"Oracles";
+
+				let maybe_stored_data =
+					get_storage_value::<Vec<T::AccountId>>(pallet_prefix, storage_item1_prefix, &[]);
+
+				if let Some(stored_data) = maybe_stored_data {
+					log::info!(
+						"pre_upgrade[{:#?}]=> Oracles count :: [{:#?}]",
+						line!(),
+						stored_data.len(),
+					);
+				} else {
+					log::info!(
+						"pre_upgrade[{:#?}]=> Oracles is_none :: [{:#?}]",
+						line!(),
+						maybe_stored_data.is_none(),
+					);
+				}
+			} else {
+				log::info!(
+					"pre_upgrade[{:#?}]=> Version mismatch. This probably should be removed",
+					line!(),
+				);
+			}
+
+			Ok(())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade() -> Result<(), &'static str> {
+			use frame_support::storage::migration::get_storage_value;
+			log::info!(
+				"post_upgrade[{:#?}]=> with current storage version {:?} / onchain {:?}",
+				line!(),
+				crate::Releases::V2_0_21,
+				<StorageVersion<T>>::get(),
+			);
+
+			if <StorageVersion<T>>::get() == Releases::V2_0_21 {
+				let pallet_prefix: &[u8] = b"Allocations";
+				let storage_item1_prefix: &[u8] = b"Oracles";
+				let storage_item2_prefix: &[u8] = b"CoinsConsumed";
+
+				assert!(get_storage_value::<Vec<T::AccountId>>(pallet_prefix, storage_item1_prefix, &[]).is_none());
+				assert!(get_storage_value::<BalanceOf<T>>(pallet_prefix, storage_item2_prefix, &[]).is_none());
+			} else {
+				log::info!(
+					"post_upgrade[{:#?}]=> Migration did not executed. This probably should be removed",
+					line!(),
+				);
+			}
+
+			Ok(())
+		}
+	}
+}

--- a/pallets/grants/Cargo.toml
+++ b/pallets/grants/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pallet-grants"
 description = "Provides scheduled balance locking mechanism, in a *graded vesting* way."
 license = "Apache-2.0"
-version = "2.0.20"
+version = "2.0.21"
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 

--- a/pallets/mandate/Cargo.toml
+++ b/pallets/mandate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-mandate"
-version = "2.0.20"
+version = "2.0.21"
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 

--- a/pallets/poa/Cargo.toml
+++ b/pallets/poa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-poa"
-version = "2.0.20"
+version = "2.0.21"
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 

--- a/pallets/reserve/Cargo.toml
+++ b/pallets/reserve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-reserve"
-version = "2.0.20"
+version = "2.0.21"
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 

--- a/pallets/staking/Cargo.toml
+++ b/pallets/staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-staking"
-version = "2.0.20"
+version = "2.0.21"
 authors = [
 	'Eliott Teissonniere <git.eliott@teissonniere.org>, R.RajeshKumar <rajesh@nodle.co>',
 ]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitives"
-version = "2.0.20"
+version = "2.0.21"
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 

--- a/runtimes/eden/Cargo.toml
+++ b/runtimes/eden/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 name = "runtime-eden"
-version = "2.0.20"
+version = "2.0.21"
 
 [features]
 default = ["std"]

--- a/runtimes/eden/src/pallets_nodle.rs
+++ b/runtimes/eden/src/pallets_nodle.rs
@@ -16,8 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 use crate::{
-	constants, pallets_governance::MoreThanHalfOfTechComm, Balances,
-	CompanyReserve, Event, Runtime, AllocationsOracles,
+	constants, pallets_governance::MoreThanHalfOfTechComm, AllocationsOracles, Balances, CompanyReserve, Event, Runtime,
 };
 use frame_support::{parameter_types, PalletId};
 use primitives::Balance;

--- a/runtimes/eden/src/pallets_nodle.rs
+++ b/runtimes/eden/src/pallets_nodle.rs
@@ -16,7 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 use crate::{
-	constants, pallets_governance::MoreThanHalfOfTechComm, Allocations, Balances, CompanyReserve, Event, Runtime,
+	constants, pallets_governance::MoreThanHalfOfTechComm, Balances,
+	CompanyReserve, Event, Runtime, AllocationsOracles,
 };
 use frame_support::{parameter_types, PalletId};
 use primitives::Balance;
@@ -37,6 +38,7 @@ impl pallet_allocations::Config for Runtime {
 	type MaximumSupply = MaximumSupply;
 	type ExistentialDeposit = <Runtime as pallet_balances::Config>::ExistentialDeposit;
 	type MaxAllocs = MaxAllocs;
+	type OracleMembers = AllocationsOracles;
 	type WeightInfo = pallet_allocations::weights::SubstrateWeight<Runtime>;
 }
 
@@ -51,8 +53,8 @@ impl pallet_membership::Config<pallet_membership::Instance2> for Runtime {
 	type SwapOrigin = MoreThanHalfOfTechComm;
 	type ResetOrigin = MoreThanHalfOfTechComm;
 	type PrimeOrigin = MoreThanHalfOfTechComm;
-	type MembershipInitialized = Allocations;
-	type MembershipChanged = Allocations;
+	type MembershipInitialized = ();
+	type MembershipChanged = ();
 	type MaxMembers = MaxMembers;
 	type WeightInfo = pallet_membership::weights::SubstrateWeight<Runtime>;
 }

--- a/support/Cargo.toml
+++ b/support/Cargo.toml
@@ -2,4 +2,4 @@
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 name = "support"
-version = "2.0.20"
+version = "2.0.21"


### PR DESCRIPTION
Part of [#173](https://github.com/NodleCode/chain-workspace/issues/173)

**HighLights**

- Storage `Oracles` is moved to bounded vector.
- Upperlimit  for  `Oracles`  is Configured via `MaxOracles`.
- Introduced new events `OracleMembersUpdated(u32)` & `OracleMembersOverFlow(u32, u32)`
- UnitTest Extension :: Done
- Runtime Integration :: Done
- Storage Migration (try_runtime) :: Done
- Benchmarking

**TODO**

**Ready for Intake Review**
