### PR TITLE
Remove without_storage_info for the grants pallet V2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: ${{ env.tarpaulin-vers }}
-          args: "--avoid-cfg-tarpaulin --all-features --workspace --timeout 120 --exclude runtimes-eden runtimes-main runtimes-staking nodle-chain nodle-parachain nodle-staking --exclude-files **/mock.rs **/weights.rs **/weights/*"
+          args: "--avoid-cfg-tarpaulin --all-features --workspace --timeout 120 --exclude runtimes-eden runtimes-main runtimes-staking nodle-chain nodle-parachain nodle-staking --exclude-files **/mock.rs **/migrations.rs **/weights.rs **/weights/*"
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3.0.0

--- a/.maintain/srtool.sh
+++ b/.maintain/srtool.sh
@@ -1,1 +1,1 @@
-docker run --rm -it -e PACKAGE=runtime-eden -e RUNTIME_DIR="runtimes/eden" -v `pwd`:/build paritytech/srtool:1.56.1
+docker run --rm -it -e PACKAGE=runtime-eden -e RUNTIME_DIR="runtimes/eden" -v `pwd`:/build paritytech/srtool:1.62.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5199,7 +5199,9 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log",
  "pallet-balances",
+ "pallet-membership",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -5207,6 +5209,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "sp-tracing",
  "support",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5214,6 +5214,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-amendments"
+version = "2.0.20"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-scheduler",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5214,23 +5214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-amendments"
-version = "2.0.20"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "pallet-scheduler",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,20 +1,20 @@
 /*
-* This file is part of the Nodle Chain distributed at https://github.com/NodleCode/chain
-* Copyright (C) 2020-2022  Nodle International
-*
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ * This file is part of the Nodle Chain distributed at https://github.com/NodleCode/chain
+ * Copyright (C) 2020-2022  Nodle International
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 // clippy complains about ChainSpecGroup which we cannot modify
 #![allow(clippy::derive_partial_eq_without_eq)]

--- a/pallets/allocations/Cargo.toml
+++ b/pallets/allocations/Cargo.toml
@@ -13,6 +13,7 @@ std = [
   "frame-support/std",
   "frame-system/std",
   "pallet-balances/std",
+  "pallet-membership/std",
   "sp-io/std",
   "sp-runtime/std",
   "sp-std/std",
@@ -22,9 +23,11 @@ runtime-benchmarks = [
   "frame-system/runtime-benchmarks",
   "frame-support/runtime-benchmarks",
 ]
+try-runtime = ["frame-support/try-runtime"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive",] }
+log = { version = "0.4.14", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 scale-info = { version = "2.0.1", default-features = false, features = [  "derive",] }
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.20" }
@@ -37,4 +40,6 @@ sp-std = { git = "https://github.com/paritytech/substrate", default-features = f
 support = { path = "../../support" }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.20" }
+sp-tracing = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.20" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.20" }
+pallet-membership = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.20" }

--- a/pallets/allocations/src/benchmarking.rs
+++ b/pallets/allocations/src/benchmarking.rs
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#![cfg_attr(tarpaulin, ignore)]
 #![cfg(feature = "runtime-benchmarks")]
 
 //! Amendments pallet benchmarks

--- a/pallets/allocations/src/migrations.rs
+++ b/pallets/allocations/src/migrations.rs
@@ -1,0 +1,145 @@
+/*
+ * This file is part of the Nodle Chain distributed at https://github.com/NodleCode/chain
+ * Copyright (C) 2020-2022  Nodle International
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pub mod v1 {
+	use crate::{Config, Releases, StorageVersion};
+
+	#[cfg(feature = "try-runtime")]
+	use crate::BalanceOf;
+
+	use frame_support::{
+		pallet_prelude::PhantomData,
+		storage::migration::{have_storage_value, remove_storage_prefix},
+		traits::{Get, OnRuntimeUpgrade},
+		weights::Weight,
+	};
+
+	pub struct MigrateToBoundedOracles<T>(PhantomData<T>);
+	impl<T: Config> OnRuntimeUpgrade for MigrateToBoundedOracles<T> {
+		fn on_runtime_upgrade() -> Weight {
+			log::info!(
+				"on_runtime_upgrade[{:#?}]=> Running migration with current storage version {:?} / onchain {:?}",
+				line!(),
+				crate::Releases::V2_0_21,
+				<StorageVersion<T>>::get(),
+			);
+
+			if <StorageVersion<T>>::get() == Releases::V0_0_0Legacy {
+				let pallet_prefix: &[u8] = b"Allocations";
+				let storage_item1_prefix: &[u8] = b"Oracles";
+				let storage_item2_prefix: &[u8] = b"CoinsConsumed";
+
+				if have_storage_value(pallet_prefix, storage_item1_prefix, &[])
+					&& have_storage_value(pallet_prefix, storage_item2_prefix, &[])
+				{
+					remove_storage_prefix(pallet_prefix, storage_item1_prefix, &[]);
+					remove_storage_prefix(pallet_prefix, storage_item2_prefix, &[]);
+
+					<StorageVersion<T>>::put(crate::Releases::V2_0_21);
+
+					log::info!(
+						"on_runtime_upgrade[{:#?}]=> Removed Oracles & CoinsConsumed, Migrated to storage version {:?}",
+						line!(),
+						<StorageVersion<T>>::get()
+					);
+				} else {
+					panic!(
+						"on_runtime_upgrade[{:#?}]=> Oracles & CoinsConsumed doesn't exist",
+						line!()
+					);
+				}
+
+				T::DbWeight::get().reads_writes(2, 2)
+			} else {
+				log::info!(
+					"on_runtime_upgrade[{:#?}]=> Migration did not executed. This probably should be removed",
+					line!(),
+				);
+				T::DbWeight::get().reads(1)
+			}
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<(), &'static str> {
+			use frame_support::storage::migration::get_storage_value;
+
+			log::info!(
+				"pre_upgrade[{:#?}]=> with current storage version {:?} / onchain {:?}",
+				line!(),
+				crate::Releases::V2_0_21,
+				<StorageVersion<T>>::get(),
+			);
+
+			if <StorageVersion<T>>::get() == Releases::V0_0_0Legacy {
+				let pallet_prefix: &[u8] = b"Allocations";
+				let storage_item1_prefix: &[u8] = b"Oracles";
+
+				let maybe_stored_data =
+					get_storage_value::<Vec<T::AccountId>>(pallet_prefix, storage_item1_prefix, &[]);
+
+				if let Some(stored_data) = maybe_stored_data {
+					log::info!(
+						"pre_upgrade[{:#?}]=> Oracles count :: [{:#?}]",
+						line!(),
+						stored_data.len(),
+					);
+				} else {
+					log::info!(
+						"pre_upgrade[{:#?}]=> Oracles is_none :: [{:#?}]",
+						line!(),
+						maybe_stored_data.is_none(),
+					);
+				}
+			} else {
+				log::info!(
+					"pre_upgrade[{:#?}]=> Version mismatch. This probably should be removed",
+					line!(),
+				);
+			}
+
+			Ok(())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade() -> Result<(), &'static str> {
+			use frame_support::storage::migration::get_storage_value;
+			log::info!(
+				"post_upgrade[{:#?}]=> with current storage version {:?} / onchain {:?}",
+				line!(),
+				crate::Releases::V2_0_21,
+				<StorageVersion<T>>::get(),
+			);
+
+			if <StorageVersion<T>>::get() == Releases::V2_0_21 {
+				let pallet_prefix: &[u8] = b"Allocations";
+				let storage_item1_prefix: &[u8] = b"Oracles";
+				let storage_item2_prefix: &[u8] = b"CoinsConsumed";
+
+				assert!(get_storage_value::<Vec<T::AccountId>>(pallet_prefix, storage_item1_prefix, &[]).is_none());
+				assert!(get_storage_value::<BalanceOf<T>>(pallet_prefix, storage_item2_prefix, &[]).is_none());
+			} else {
+				log::info!(
+					"post_upgrade[{:#?}]=> Migration did not executed. This probably should be removed",
+					line!(),
+				);
+			}
+
+			Ok(())
+		}
+	}
+}

--- a/pallets/grants/Cargo.toml
+++ b/pallets/grants/Cargo.toml
@@ -27,6 +27,7 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 ]
+try-runtime = ["frame-support/try-runtime"]
 
 [dependencies]
 log = { version = "0.4.14", default-features = false }

--- a/pallets/grants/src/benchmarking.rs
+++ b/pallets/grants/src/benchmarking.rs
@@ -87,7 +87,7 @@ benchmarks! {
 	   let config = create_shared_config::<T>(1);
 
 		// Add some existing schedules according to b
-		for x in 0 .. T::MaxSchedule::get().saturating_sub(1) {
+		for _x in 1 .. T::MaxSchedule::get() {
 			Pallet::<T>::do_add_vesting_schedule(&config.granter, &config.grantee, config.schedule.clone())?;
 		}
 

--- a/pallets/grants/src/benchmarking.rs
+++ b/pallets/grants/src/benchmarking.rs
@@ -78,7 +78,7 @@ benchmarks! {
 		Pallet::<T>::do_add_vesting_schedule(&config.granter, &config.grantee, config.schedule.clone())?;
 
 		// Add some existing schedules according to b
-		for x in 0 .. T::MaxSchedule::get().saturating_sub(1) {
+		for _x in 1 .. T::MaxSchedule::get() {
 			Pallet::<T>::do_add_vesting_schedule(&config.granter, &config.grantee, config.schedule.clone())?;
 		}
 	}: _(RawOrigin::Signed(config.grantee))

--- a/pallets/grants/src/benchmarking.rs
+++ b/pallets/grants/src/benchmarking.rs
@@ -68,7 +68,7 @@ benchmarks! {
 		let config = create_shared_config::<T>(1);
 
 		// Add some existing schedules according to b
-		for x in 0 .. T::MaxSchedule::get().saturating_sub(1) {
+		for _x in 1 .. T::MaxSchedule::get() {
 			Pallet::<T>::do_add_vesting_schedule(&config.granter, &config.grantee, config.schedule.clone())?;
 		}
 	}:  _(RawOrigin::Signed(config.granter.clone()), config.grantee_lookup.clone(), config.schedule.clone())

--- a/pallets/grants/src/benchmarking.rs
+++ b/pallets/grants/src/benchmarking.rs
@@ -28,7 +28,6 @@ use frame_system::RawOrigin;
 use sp_runtime::traits::Bounded;
 use sp_std::prelude::*;
 
-const MAX_SCHEDULES: u32 = 100;
 const SEED: u32 = 0;
 
 struct BenchmarkConfig<T: Config> {
@@ -69,7 +68,7 @@ benchmarks! {
 		let config = create_shared_config::<T>(1);
 
 		// Add some existing schedules according to b
-		for x in 0 .. MAX_SCHEDULES {
+		for x in 0 .. T::MaxSchedule::get().saturating_sub(1) {
 			Pallet::<T>::do_add_vesting_schedule(&config.granter, &config.grantee, config.schedule.clone())?;
 		}
 	}:  _(RawOrigin::Signed(config.granter.clone()), config.grantee_lookup.clone(), config.schedule.clone())
@@ -79,7 +78,7 @@ benchmarks! {
 		Pallet::<T>::do_add_vesting_schedule(&config.granter, &config.grantee, config.schedule.clone())?;
 
 		// Add some existing schedules according to b
-		for x in 0 .. MAX_SCHEDULES {
+		for x in 0 .. T::MaxSchedule::get().saturating_sub(1) {
 			Pallet::<T>::do_add_vesting_schedule(&config.granter, &config.grantee, config.schedule.clone())?;
 		}
 	}: _(RawOrigin::Signed(config.grantee))
@@ -88,7 +87,7 @@ benchmarks! {
 	   let config = create_shared_config::<T>(1);
 
 		// Add some existing schedules according to b
-		for x in 0 .. MAX_SCHEDULES {
+		for x in 0 .. T::MaxSchedule::get().saturating_sub(1) {
 			Pallet::<T>::do_add_vesting_schedule(&config.granter, &config.grantee, config.schedule.clone())?;
 		}
 

--- a/pallets/grants/src/lib.rs
+++ b/pallets/grants/src/lib.rs
@@ -26,10 +26,14 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
+mod migrations;
+
 use codec::{Decode, Encode};
 use frame_support::{
 	ensure,
-	traits::{Currency, ExistenceRequirement, LockIdentifier, LockableCurrency, WithdrawReasons},
+	pallet_prelude::*,
+	traits::{Currency, ExistenceRequirement, LockIdentifier, LockableCurrency, OnRuntimeUpgrade, WithdrawReasons},
+	BoundedVec,
 };
 use sp_runtime::{
 	traits::{AtLeast32Bit, BlockNumberProvider, CheckedAdd, Saturating, StaticLookup, Zero},
@@ -48,6 +52,21 @@ pub use weights::WeightInfo;
 
 pub use pallet::*;
 
+// A value placed in storage that represents the current version of the POA storage.
+// This value is used by the `on_runtime_upgrade` logic to determine whether we run storage
+// migration logic. This should match directly with the semantic versions of the Rust crate.
+#[derive(Encode, MaxEncodedLen, Decode, Clone, Copy, PartialEq, Eq, RuntimeDebug, TypeInfo)]
+enum Releases {
+	V0_0_0Legacy, // To handle Legacy version
+	V2_0_21,
+}
+
+impl Default for Releases {
+	fn default() -> Self {
+		Releases::V0_0_0Legacy
+	}
+}
+
 pub type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 pub type VestingScheduleOf<T> = VestingSchedule<<T as frame_system::Config>::BlockNumber, BalanceOf<T>>;
 pub type ListVestingScheduleOf<T> = Vec<VestingScheduleOf<T>>;
@@ -63,7 +82,7 @@ pub type ScheduledItem<T> = (<T as frame_system::Config>::AccountId, Vec<Schedul
 ///
 /// Benefits would be granted gradually, `per_period` amount every `period` of blocks
 /// after `start`.
-#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, scale_info::TypeInfo)]
+#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, MaxEncodedLen, scale_info::TypeInfo)]
 pub struct VestingSchedule<BlockNumber, Balance> {
 	pub start: BlockNumber,
 	pub period: BlockNumber,
@@ -103,7 +122,6 @@ impl<BlockNumber: AtLeast32Bit + Copy, Balance: AtLeast32Bit + Copy> VestingSche
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
 
 	#[pallet::config]
@@ -112,6 +130,9 @@ pub mod pallet {
 		type Currency: LockableCurrency<Self::AccountId, Moment = Self::BlockNumber>;
 		type CancelOrigin: EnsureOrigin<Self::Origin>;
 		type ForceOrigin: EnsureOrigin<Self::Origin>;
+		/// The maximum number of vesting schedule.
+		#[pallet::constant]
+		type MaxSchedule: Get<u32>;
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
 		// The block number provider
@@ -120,11 +141,24 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(PhantomData<T>);
 
 	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<(), &'static str> {
+			migrations::v1::MigrateToBoundedVestingSchedules::<T>::pre_upgrade()
+		}
+
+		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+			migrations::v1::MigrateToBoundedVestingSchedules::<T>::on_runtime_upgrade()
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade() -> Result<(), &'static str> {
+			migrations::v1::MigrateToBoundedVestingSchedules::<T>::post_upgrade()
+		}
+	}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
@@ -136,7 +170,7 @@ pub mod pallet {
 
 			if locked_amount.is_zero() {
 				// No more claimable, clear
-				VestingSchedules::<T>::remove(who.clone());
+				<VestingSchedules<T>>::remove(who.clone());
 			}
 
 			Self::deposit_event(Event::Claimed(who, locked_amount));
@@ -186,7 +220,7 @@ pub mod pallet {
 				collectable_funds,
 				ExistenceRequirement::AllowDeath,
 			)?;
-			VestingSchedules::<T>::remove(account_with_schedule.clone());
+			<VestingSchedules<T>>::remove(account_with_schedule.clone());
 
 			Self::deposit_event(Event::VestingSchedulesCanceled(account_with_schedule));
 
@@ -213,12 +247,21 @@ pub mod pallet {
 		InsufficientBalanceToLock,
 		EmptySchedules,
 		VestingToSelf,
+		MaxScheduleOverflow,
 	}
 
 	#[pallet::storage]
 	#[pallet::getter(fn vesting_schedules)]
-	pub type VestingSchedules<T: Config> =
-		StorageMap<_, Blake2_128Concat, T::AccountId, Vec<VestingScheduleOf<T>>, ValueQuery>;
+	pub type VestingSchedules<T: Config> = CountedStorageMap<
+		_,
+		Blake2_128Concat,
+		T::AccountId,
+		BoundedVec<VestingScheduleOf<T>, T::MaxSchedule>,
+		ValueQuery,
+	>;
+
+	#[pallet::storage]
+	pub(crate) type StorageVersion<T: Config> = StorageValue<_, Releases, ValueQuery>;
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
@@ -237,34 +280,26 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
-			let grants = self
-				.vesting
-				.iter()
-				.map(|(ref who, schedules)| {
-					(
-						who.clone(),
-						schedules
-							.iter()
-							.map(|&(start, period, period_count, per_period)| VestingSchedule {
-								start,
-								period,
-								period_count,
-								per_period,
-							})
-							.collect::<Vec<_>>(),
-					)
-				})
-				.collect::<Vec<_>>();
+			self.vesting.iter().for_each(|(ref who, schedules)| {
+				let vesting_schedule: BoundedVec<VestingScheduleOf<T>, T::MaxSchedule> = schedules
+					.iter()
+					.map(|&(start, period, period_count, per_period)| VestingSchedule {
+						start,
+						period,
+						period_count,
+						per_period,
+					})
+					.collect::<Vec<_>>()
+					.try_into()
+					.expect("Genesis Init Failed Vesting Schedules Overflow");
 
-			// Create the required coins at genesis and add to storage
-			grants.iter().for_each(|(ref who, schedules)| {
-				let total_grants = schedules.iter().fold(Zero::zero(), |acc: BalanceOf<T>, s| {
+				let total_grants = vesting_schedule.iter().fold(Zero::zero(), |acc: BalanceOf<T>, s| {
 					acc.saturating_add(s.locked_amount(Zero::zero()))
 				});
 
 				T::Currency::resolve_creating(who, T::Currency::issue(total_grants));
 				T::Currency::set_lock(VESTING_LOCK_ID, who, total_grants, WithdrawReasons::all());
-				<VestingSchedules<T>>::insert(who, schedules);
+				<VestingSchedules<T>>::insert(who, vesting_schedule);
 			});
 		}
 	}
@@ -303,13 +338,11 @@ impl<T: Config> Pallet<T> {
 	/// Returns locked balance based on current block number.
 	fn locked_balance(who: &T::AccountId) -> BalanceOf<T> {
 		let now = T::BlockNumberProvider::current_block_number();
-		Self::vesting_schedules(who)
-            .iter()
-            .fold(Zero::zero(), |acc, s| {
-                acc.checked_add(&s.locked_amount(now)).expect(
-                    "locked amount is a balance and can't be higher than the total balance stored inside the same integer type; qed",
-                )
-            })
+		Self::vesting_schedules(who).iter().fold(Zero::zero(), |acc, s| {
+			acc.checked_add(&s.locked_amount(now)).expect(
+					  "locked amount is a balance and can't be higher than the total balance stored inside the same integer type; qed",
+				  )
+		})
 	}
 
 	fn do_add_vesting_schedule(
@@ -324,9 +357,16 @@ impl<T: Config> Pallet<T> {
 			.checked_add(&schedule_amount)
 			.ok_or(Error::<T>::NumOverflow)?;
 
-		T::Currency::transfer(from, to, schedule_amount, ExistenceRequirement::AllowDeath)?;
-		T::Currency::set_lock(VESTING_LOCK_ID, to, total_amount, WithdrawReasons::all());
-		<VestingSchedules<T>>::mutate(to, |v| (*v).push(schedule));
+		<VestingSchedules<T>>::try_mutate(to, |vesting_schedules| -> DispatchResult {
+			vesting_schedules
+				.try_push(schedule)
+				.map_err(|_| <Error<T>>::MaxScheduleOverflow)?;
+
+			T::Currency::transfer(from, to, schedule_amount, ExistenceRequirement::AllowDeath)?;
+			T::Currency::set_lock(VESTING_LOCK_ID, to, total_amount, WithdrawReasons::all());
+
+			Ok(())
+		})?;
 
 		Ok(())
 	}

--- a/pallets/grants/src/migrations.rs
+++ b/pallets/grants/src/migrations.rs
@@ -1,0 +1,183 @@
+/*
+ * This file is part of the Nodle Chain distributed at https://github.com/NodleCode/chain
+ * Copyright (C) 2020-2022  Nodle International
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pub mod v1 {
+	use crate::{Config, Releases, StorageVersion, VestingScheduleOf, VestingSchedules};
+	use frame_support::{
+		pallet_prelude::PhantomData,
+		storage::migration::storage_key_iter,
+		traits::{Get, OnRuntimeUpgrade},
+		weights::Weight,
+		Blake2_128Concat, BoundedVec,
+	};
+	use sp_runtime::traits::Saturating;
+	use sp_std::convert::TryInto;
+	use sp_std::vec::Vec;
+
+	pub struct MigrateToBoundedVestingSchedules<T>(PhantomData<T>);
+	impl<T: Config> OnRuntimeUpgrade for MigrateToBoundedVestingSchedules<T> {
+		fn on_runtime_upgrade() -> Weight {
+			log::info!(
+				"on_runtime_upgrade[{:#?}]=> Running migration with current storage version {:?} / onchain {:?}",
+				line!(),
+				crate::Releases::V2_0_21,
+				<StorageVersion<T>>::get(),
+			);
+
+			if <StorageVersion<T>>::get() == Releases::V0_0_0Legacy {
+				let pallet_prefix: &[u8] = b"Vesting";
+				let storage_item_prefix: &[u8] = b"VestingSchedules";
+
+				// Check number of entries, and set it aside in temp storage
+				let stored_data: Vec<_> =
+					storage_key_iter::<T::AccountId, Vec<VestingScheduleOf<T>>, Blake2_128Concat>(
+						pallet_prefix,
+						storage_item_prefix,
+					)
+					.collect();
+
+				let mut translated = 0u64;
+				let mut max_schedules: usize = 0;
+
+				assert!(!stored_data.is_empty());
+
+				// Write to the new storage with removed and added fields
+				for (account, old_vesting) in stored_data {
+					translated.saturating_inc();
+					max_schedules = max_schedules.max(old_vesting.len());
+					let new_vesting: BoundedVec<VestingScheduleOf<T>, T::MaxSchedule> = old_vesting
+						.clone()
+						.try_into()
+						.map_err(|err| {
+							log::error!(
+								"on_runtime_upgrade[{:#?}]=> Schedule length :: {:#?} Max :: {:#?}",
+								line!(),
+								old_vesting.len(),
+								T::MaxSchedule::get()
+							);
+							err
+						})
+						.expect("Could be boundedvec Overflow");
+
+					<VestingSchedules<T>>::insert(account, new_vesting);
+				}
+
+				<StorageVersion<T>>::put(crate::Releases::V2_0_21);
+
+				log::info!(
+					"on_runtime_upgrade[{:#?}]=> Upgraded {} schedules, Max {}, storage to version {:?}",
+					line!(),
+					translated,
+					max_schedules,
+					<StorageVersion<T>>::get()
+				);
+
+				T::DbWeight::get().reads_writes(translated + 1, translated + 1)
+			} else {
+				log::info!(
+					"on_runtime_upgrade[{:#?}]=> Migration did not executed. This probably should be removed",
+					line!(),
+				);
+				T::DbWeight::get().reads(1)
+			}
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<(), &'static str> {
+			use frame_support::traits::OnRuntimeUpgradeHelpersExt;
+
+			log::info!(
+				"pre_upgrade[{:#?}]=> with current storage version {:?} / onchain {:?}",
+				line!(),
+				crate::Releases::V2_0_21,
+				<StorageVersion<T>>::get(),
+			);
+
+			if <StorageVersion<T>>::get() == Releases::V0_0_0Legacy {
+				let pallet_prefix: &[u8] = b"Vesting";
+				let storage_item_prefix: &[u8] = b"VestingSchedules";
+
+				// Check number of entries, and set it aside in temp storage
+				let stored_data: Vec<_> =
+					storage_key_iter::<T::AccountId, Vec<VestingScheduleOf<T>>, Blake2_128Concat>(
+						pallet_prefix,
+						storage_item_prefix,
+					)
+					.collect();
+
+				let mapping_count: u32 = stored_data.len() as u32;
+				Self::set_temp_storage(mapping_count, "mapping_count");
+
+				stored_data
+					.iter()
+					.for_each(|(_account, old_vesting)| assert!(old_vesting.len() <= T::MaxSchedule::get() as usize));
+
+				log::info!(
+					"pre_upgrade[{:#?}]=> VestingSchedules map count :: [{:#?}]",
+					line!(),
+					mapping_count,
+				);
+			} else {
+				log::info!(
+					"pre_upgrade[{:#?}]=> Migration did not executed. This probably should be removed",
+					line!(),
+				);
+			}
+			Ok(())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade() -> Result<(), &'static str> {
+			use frame_support::traits::OnRuntimeUpgradeHelpersExt;
+
+			log::info!(
+				"post_upgrade[{:#?}]=> with current storage version {:?} / onchain {:?}",
+				line!(),
+				crate::Releases::V2_0_21,
+				<StorageVersion<T>>::get(),
+			);
+
+			if <StorageVersion<T>>::get() == Releases::V2_0_21 {
+				let pallet_prefix: &[u8] = b"Vesting";
+				let storage_item_prefix: &[u8] = b"VestingSchedules";
+
+				let mapping_count: u32 = storage_key_iter::<
+					T::AccountId,
+					BoundedVec<VestingScheduleOf<T>, T::MaxSchedule>,
+					Blake2_128Concat,
+				>(pallet_prefix, storage_item_prefix)
+				.count() as u32;
+
+				log::info!(
+					"post_upgrade[{:#?}]=> VestingSchedules map count :: [{:#?}]",
+					line!(),
+					mapping_count,
+				);
+
+				assert!(Some(mapping_count) == Self::get_temp_storage::<u32>("mapping_count"));
+			} else {
+				log::info!(
+					"post_upgrade[{:#?}]=> Migration did not executed. This probably should be removed",
+					line!(),
+				);
+			}
+
+			Ok(())
+		}
+	}
+}

--- a/pallets/grants/src/mock.rs
+++ b/pallets/grants/src/mock.rs
@@ -119,9 +119,6 @@ pub const BOB: AccountId = 2;
 pub(crate) fn context_events() -> Vec<pallet::Event<Test>> {
 	System::events()
 		.into_iter()
-		.map(|r| r.event)
-		.filter_map(|e| {
-		.into_iter()
 		.filter_map(|r| {
 			if let Event::Vesting(inner) = r.event {
 				Some(inner)

--- a/pallets/grants/src/mock.rs
+++ b/pallets/grants/src/mock.rs
@@ -99,11 +99,16 @@ ord_parameter_types! {
 	pub const ForceOrigin: AccountId = 43;
 }
 
+parameter_types! {
+	pub static MaxSchedule: u32 = 2;
+}
+
 impl Config for Test {
 	type Event = Event;
 	type Currency = PalletBalances;
 	type CancelOrigin = EnsureSignedBy<CancelOrigin, AccountId>;
 	type ForceOrigin = EnsureSignedBy<ForceOrigin, AccountId>;
+	type MaxSchedule = MaxSchedule;
 	type WeightInfo = ();
 	type BlockNumberProvider = frame_system::Pallet<Test>;
 }
@@ -111,16 +116,23 @@ impl Config for Test {
 pub const ALICE: AccountId = 1;
 pub const BOB: AccountId = 2;
 
-pub struct ExtBuilder {
-	endowed_accounts: Vec<(AccountId, Balance)>,
+pub(crate) fn context_events() -> Vec<pallet::Event<Test>> {
+	System::events()
+		.into_iter()
+		.map(|r| r.event)
+		.filter_map(|e| {
+			if let Event::Vesting(inner) = e {
+				Some(inner)
+			} else {
+				None
+			}
+		})
+		.collect::<Vec<_>>()
 }
 
-impl Default for ExtBuilder {
-	fn default() -> Self {
-		Self {
-			endowed_accounts: vec![],
-		}
-	}
+#[derive(Default)]
+pub struct ExtBuilder {
+	endowed_accounts: Vec<(AccountId, Balance)>,
 }
 
 impl ExtBuilder {

--- a/pallets/grants/src/mock.rs
+++ b/pallets/grants/src/mock.rs
@@ -121,7 +121,9 @@ pub(crate) fn context_events() -> Vec<pallet::Event<Test>> {
 		.into_iter()
 		.map(|r| r.event)
 		.filter_map(|e| {
-			if let Event::Vesting(inner) = e {
+		.into_iter()
+		.filter_map(|r| {
+			if let Event::Vesting(inner) = r.event {
 				Some(inner)
 			} else {
 				None

--- a/pallets/grants/src/tests.rs
+++ b/pallets/grants/src/tests.rs
@@ -292,7 +292,7 @@ fn cancel_tolerates_corrupted_state() {
 
 		// We also add some vesting schedules without any balances to simulate
 		// a corrupted / badly canceled state.
-		<VestingSchedules<Runtime>>::mutate(BOB, |s| {
+		assert_ok!(<VestingSchedules<Runtime>>::try_mutate(BOB, |s| -> Result<(), ()> {
 			let _ = s
 				.try_push(VestingSchedule {
 					start: 0u64,

--- a/pallets/grants/src/tests.rs
+++ b/pallets/grants/src/tests.rs
@@ -288,7 +288,7 @@ fn cancel_tolerates_corrupted_state() {
 
 		// We also add some vesting schedules without any balances to simulate
 		// a corrupted / badly canceled state.
-		<VestingSchedules<Runtime>>::mutate(BOB, |s| {
+		assert_ok!(<VestingSchedules<Runtime>>::try_mutate(BOB, |s| -> Result<(), ()> {
 			let _ = s
 				.try_push(VestingSchedule {
 					start: 0u64,
@@ -298,8 +298,10 @@ fn cancel_tolerates_corrupted_state() {
 				})
 				.map_err(|err| {
 					log::error!("Exceeds vesting schedule max: {:#?}", err);
-				});
-		});
+					()
+				})?;
+			Ok(())
+		}));
 
 		System::set_block_number(11);
 

--- a/pallets/grants/src/tests.rs
+++ b/pallets/grants/src/tests.rs
@@ -476,6 +476,6 @@ fn add_vesting_schedule_overflow_cfg_max_check() {
 			);
 
 			assert_eq!(Vesting::vesting_schedules(&BOB).to_vec().len() as u32, schedule_max);
-			assert_eq!(context_events().len() as u32, schedule_max);
+			assert_eq!(context_events().len(), schedule_max as usize);
 		});
 }

--- a/pallets/grants/src/tests.rs
+++ b/pallets/grants/src/tests.rs
@@ -292,15 +292,17 @@ fn cancel_tolerates_corrupted_state() {
 
 		// We also add some vesting schedules without any balances to simulate
 		// a corrupted / badly canceled state.
-		let bob_modified_vesting_schedule = VestingSchedule {
-			start: 0u64,
-			period: 10u64,
-			period_count: 2u32,
-			per_period: 1_000u64, // definitely too much money
-		};
-
-		let ans = <VestingSchedules<Runtime>>::try_mutate(BOB, |s| -> Result<(), ()> {
-			s.try_push(bob_modified_vesting_schedule.clone())
+		<VestingSchedules<Runtime>>::mutate(BOB, |s| {
+			let _ = s
+				.try_push(VestingSchedule {
+					start: 0u64,
+					period: 10u64,
+					period_count: 2u32,
+					per_period: 1_000u64, // definitely too much money
+				})
+				.map_err(|err| {
+					log::error!("Exceeds vesting schedule max: {:#?}", err);
+				});
 		});
 		assert_ok!(ans);
 

--- a/pallets/grants/src/tests.rs
+++ b/pallets/grants/src/tests.rs
@@ -375,6 +375,7 @@ fn cancel_tolerates_corrupted_state() {
 			assert_eq!(schedule_from_chain[0], allice_vesting_to_bob_schedule);
 			assert_eq!(schedule_from_chain[1], bob_modified_vesting_schedule);
 		} else {
+			#[cfg_attr(tarpaulin, ignore)]
 			panic!("Code expected to be dead is alive");
 		}
 

--- a/pallets/grants/src/tests.rs
+++ b/pallets/grants/src/tests.rs
@@ -475,7 +475,7 @@ fn add_vesting_schedule_overflow_cfg_max_check() {
 				<Error<Runtime>>::MaxScheduleOverflow,
 			);
 
-			assert_eq!(Vesting::vesting_schedules(&BOB).to_vec().len() as u32, schedule_max);
+			assert_eq!(Vesting::vesting_schedules(&BOB).to_vec().len(), schedule_max as usize);
 			assert_eq!(context_events().len(), schedule_max as usize);
 		});
 }

--- a/pallets/grants/src/tests.rs
+++ b/pallets/grants/src/tests.rs
@@ -23,7 +23,8 @@
 use super::*;
 use frame_support::{assert_err, assert_noop, assert_ok, traits::WithdrawReasons};
 use mock::{
-	CancelOrigin, Event as TestEvent, ExtBuilder, Origin, PalletBalances, System, Test as Runtime, Vesting, ALICE, BOB,
+	context_events, CancelOrigin, Event as TestEvent, ExtBuilder, Origin, PalletBalances, System, Test as Runtime,
+	Vesting, ALICE, BOB,
 };
 use pallet_balances::{BalanceLock, Reasons};
 use sp_runtime::DispatchError::BadOrigin;
@@ -191,7 +192,7 @@ fn claim_works() {
 		// more are still locked
 		assert!(PalletBalances::transfer(Origin::signed(BOB), ALICE, 1).is_err());
 		// does not clear storage
-		assert!(VestingSchedules::<Runtime>::contains_key(BOB));
+		assert!(<VestingSchedules<Runtime>>::contains_key(BOB));
 
 		System::set_block_number(21);
 		// claim more
@@ -200,7 +201,7 @@ fn claim_works() {
 		// all used up
 		assert_eq!(PalletBalances::free_balance(BOB), 0);
 		// clears the storage
-		assert!(!VestingSchedules::<Runtime>::contains_key(BOB));
+		assert!(!<VestingSchedules<Runtime>>::contains_key(BOB));
 		// no locks anymore
 		assert_eq!(PalletBalances::locks(&BOB), vec![]);
 	});
@@ -262,7 +263,7 @@ fn cancel_clears_storage() {
 			CancelOrigin::get()
 		));
 
-		assert!(!VestingSchedules::<Runtime>::contains_key(BOB));
+		assert!(!<VestingSchedules<Runtime>>::contains_key(BOB));
 	});
 }
 
@@ -279,13 +280,17 @@ fn cancel_tolerates_corrupted_state() {
 
 		// We also add some vesting schedules without any balances to simulate
 		// a corrupted / badly canceled state.
-		VestingSchedules::<Runtime>::mutate(BOB, |s| {
-			s.push(VestingSchedule {
-				start: 0u64,
-				period: 10u64,
-				period_count: 2u32,
-				per_period: 1_000u64, // definitely too much money
-			})
+		<VestingSchedules<Runtime>>::mutate(BOB, |s| {
+			let _ = s
+				.try_push(VestingSchedule {
+					start: 0u64,
+					period: 10u64,
+					period_count: 2u32,
+					per_period: 1_000u64, // definitely too much money
+				})
+				.map_err(|err| {
+					log::error!("Exceeds vesting schedule max: {:#?}", err);
+				});
 		});
 
 		System::set_block_number(11);
@@ -296,7 +301,7 @@ fn cancel_tolerates_corrupted_state() {
 			CancelOrigin::get(),
 		));
 
-		assert!(!VestingSchedules::<Runtime>::contains_key(BOB));
+		assert!(!<VestingSchedules<Runtime>>::contains_key(BOB));
 	});
 }
 
@@ -317,4 +322,150 @@ fn cannot_vest_to_self() {
 			Error::<Runtime>::VestingToSelf
 		);
 	});
+}
+
+#[test]
+fn add_vesting_schedule_overflow_check() {
+	ExtBuilder::default()
+		.balances(vec![(ALICE, 1000)])
+		.build()
+		.execute_with(|| {
+			System::set_block_number(1);
+
+			let schedules = vec![
+				VestingSchedule {
+					start: 0u64,
+					period: 10u64,
+					period_count: 1u32,
+					per_period: 100u64,
+				},
+				VestingSchedule {
+					start: 0u64,
+					period: 10u64,
+					period_count: 1u32,
+					per_period: 100u64,
+				},
+				VestingSchedule {
+					start: 0u64,
+					period: 10u64,
+					period_count: 1u32,
+					per_period: 100u64,
+				},
+			];
+
+			assert_ok!(Vesting::add_vesting_schedule(
+				Origin::signed(ALICE),
+				BOB,
+				schedules[0].clone(),
+			));
+			assert_eq!(Vesting::vesting_schedules(&BOB).to_vec().len(), 1);
+
+			let expected = vec![Event::VestingScheduleAdded(1, 2, schedules[0].clone())];
+
+			assert_eq!(context_events(), expected);
+
+			assert_ok!(Vesting::add_vesting_schedule(
+				Origin::signed(ALICE),
+				BOB,
+				schedules[1].clone(),
+			));
+			assert_eq!(Vesting::vesting_schedules(&BOB).to_vec().len(), 2);
+
+			let expected = vec![
+				Event::VestingScheduleAdded(1, 2, schedules[0].clone()),
+				Event::VestingScheduleAdded(1, 2, schedules[1].clone()),
+			];
+
+			assert_eq!(context_events(), expected);
+
+			assert_err!(
+				Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, schedules[2].clone(),),
+				<Error<Runtime>>::MaxScheduleOverflow,
+			);
+
+			assert_eq!(Vesting::vesting_schedules(&BOB).to_vec().len(), 2);
+		});
+}
+
+#[test]
+fn add_vesting_schedule_overflow_cfg_min_check() {
+	ExtBuilder::default()
+		.balances(vec![(ALICE, 1000)])
+		.build()
+		.execute_with(|| {
+			System::set_block_number(1);
+
+			let schedules = vec![VestingSchedule {
+				start: 0u64,
+				period: 10u64,
+				period_count: 1u32,
+				per_period: 100u64,
+			}];
+
+			mock::MAX_SCHEDULE.with(|v| *v.borrow_mut() = 0);
+
+			assert_eq!(Vesting::vesting_schedules(&BOB).to_vec().len(), 0);
+
+			assert_err!(
+				Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, schedules[0].clone(),),
+				<Error<Runtime>>::MaxScheduleOverflow,
+			);
+
+			assert_eq!(Vesting::vesting_schedules(&BOB).to_vec().len(), 0);
+
+			let expected = vec![];
+			assert_eq!(context_events(), expected);
+
+			mock::MAX_SCHEDULE.with(|v| *v.borrow_mut() = 1);
+
+			assert_ok!(Vesting::add_vesting_schedule(
+				Origin::signed(ALICE),
+				BOB,
+				schedules[0].clone(),
+			));
+			assert_eq!(Vesting::vesting_schedules(&BOB).to_vec().len(), 1);
+
+			let expected = vec![Event::VestingScheduleAdded(1, 2, schedules[0].clone())];
+
+			assert_eq!(context_events(), expected);
+		});
+}
+
+#[test]
+fn add_vesting_schedule_overflow_cfg_max_check() {
+	ExtBuilder::default()
+		.balances(vec![(ALICE, 10_000_000)])
+		.build()
+		.execute_with(|| {
+			System::set_block_number(1);
+
+			let schedules = vec![VestingSchedule {
+				start: 0u64,
+				period: 10u64,
+				period_count: 1u32,
+				per_period: 100u64,
+			}];
+
+			let schedule_max = 500;
+
+			mock::MAX_SCHEDULE.with(|v| *v.borrow_mut() = schedule_max);
+
+			(0..schedule_max).into_iter().for_each(|iter_index| {
+				assert_ok!(Vesting::add_vesting_schedule(
+					Origin::signed(ALICE),
+					BOB,
+					schedules[0].clone(),
+				));
+				assert_eq!(Vesting::vesting_schedules(&BOB).to_vec().len() as u32, iter_index + 1);
+				assert_eq!(context_events().len() as u32, iter_index + 1);
+			});
+
+			assert_err!(
+				Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, schedules[0].clone(),),
+				<Error<Runtime>>::MaxScheduleOverflow,
+			);
+
+			assert_eq!(Vesting::vesting_schedules(&BOB).to_vec().len() as u32, schedule_max);
+			assert_eq!(context_events().len() as u32, schedule_max);
+		});
 }

--- a/pallets/grants/src/tests.rs
+++ b/pallets/grants/src/tests.rs
@@ -30,6 +30,14 @@ use pallet_balances::{BalanceLock, Reasons};
 use sp_runtime::DispatchError::BadOrigin;
 
 #[test]
+fn check_releases_default_config() {
+	ExtBuilder::default().build().execute_with(|| {
+		let releases = Releases::default();
+		assert_eq!(releases, Releases::V0_0_0Legacy);
+		assert_ne!(releases, Releases::V2_0_21);
+	})
+}
+#[test]
 fn add_vesting_schedule_works() {
 	ExtBuilder::default().one_hundred_for_alice().build().execute_with(|| {
 		System::set_block_number(1);

--- a/pallets/grants/src/tests.rs
+++ b/pallets/grants/src/tests.rs
@@ -49,13 +49,13 @@ fn add_vesting_schedule_works() {
 			per_period: 100u64,
 		};
 		assert_ok!(Vesting::add_vesting_schedule(
-			Origin::signed(ALICE),
-			BOB,
+			Origin::signed(ALICE::get()),
+			BOB::get(),
 			schedule.clone()
 		));
-		assert_eq!(Vesting::vesting_schedules(&BOB), vec![schedule.clone()]);
+		assert_eq!(Vesting::vesting_schedules(&BOB::get()), vec![schedule.clone()]);
 
-		let vested_event = TestEvent::Vesting(Event::VestingScheduleAdded(ALICE, BOB, schedule));
+		let vested_event = TestEvent::Vesting(Event::VestingScheduleAdded(ALICE::get(), BOB::get(), schedule));
 		assert!(System::events().iter().any(|record| record.event == vested_event));
 	});
 }
@@ -69,7 +69,11 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
 			period_count: 2u32,
 			per_period: 10u64,
 		};
-		assert_ok!(Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, schedule));
+		assert_ok!(Vesting::add_vesting_schedule(
+			Origin::signed(ALICE::get()),
+			BOB::get(),
+			schedule
+		));
 
 		System::set_block_number(12);
 
@@ -80,13 +84,13 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
 			per_period: 7u64,
 		};
 		assert_ok!(Vesting::add_vesting_schedule(
-			Origin::signed(ALICE),
-			BOB,
+			Origin::signed(ALICE::get()),
+			BOB::get(),
 			another_schedule
 		));
 
 		assert_eq!(
-			PalletBalances::locks(&BOB).to_vec().pop(),
+			PalletBalances::locks(&BOB::get()).to_vec().pop(),
 			Some(BalanceLock {
 				id: VESTING_LOCK_ID,
 				amount: 17u64,
@@ -105,8 +109,12 @@ fn cannot_use_fund_if_not_claimed() {
 			period_count: 1u32,
 			per_period: 50u64,
 		};
-		assert_ok!(Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, schedule));
-		assert!(PalletBalances::ensure_can_withdraw(&BOB, 1, WithdrawReasons::TRANSFER, 49).is_err());
+		assert_ok!(Vesting::add_vesting_schedule(
+			Origin::signed(ALICE::get()),
+			BOB::get(),
+			schedule
+		));
+		assert!(PalletBalances::ensure_can_withdraw(&BOB::get(), 1, WithdrawReasons::TRANSFER, 49).is_err());
 	});
 }
 
@@ -120,7 +128,7 @@ fn add_vesting_schedule_fails_if_zero_period_or_count() {
 			per_period: 100u64,
 		};
 		assert_err!(
-			Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, schedule),
+			Vesting::add_vesting_schedule(Origin::signed(ALICE::get()), BOB::get(), schedule),
 			Error::<Runtime>::ZeroVestingPeriod
 		);
 
@@ -131,7 +139,7 @@ fn add_vesting_schedule_fails_if_zero_period_or_count() {
 			per_period: 100u64,
 		};
 		assert_err!(
-			Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, schedule),
+			Vesting::add_vesting_schedule(Origin::signed(ALICE::get()), BOB::get(), schedule),
 			Error::<Runtime>::ZeroVestingPeriodCount
 		);
 	});
@@ -147,7 +155,7 @@ fn add_vesting_schedule_fails_if_transfer_err() {
 			per_period: 100u64,
 		};
 		assert_err!(
-			Vesting::add_vesting_schedule(Origin::signed(BOB), ALICE, schedule),
+			Vesting::add_vesting_schedule(Origin::signed(BOB::get()), ALICE::get(), schedule),
 			pallet_balances::Error::<Runtime, _>::InsufficientBalance,
 		);
 	});
@@ -163,7 +171,7 @@ fn add_vesting_schedule_fails_if_overflow() {
 			per_period: u64::max_value(),
 		};
 		assert_err!(
-			Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, schedule),
+			Vesting::add_vesting_schedule(Origin::signed(ALICE::get()), BOB::get(), schedule),
 			Error::<Runtime>::NumOverflow
 		);
 
@@ -174,7 +182,7 @@ fn add_vesting_schedule_fails_if_overflow() {
 			per_period: 1u64,
 		};
 		assert_err!(
-			Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, another_schedule),
+			Vesting::add_vesting_schedule(Origin::signed(ALICE::get()), BOB::get(), another_schedule),
 			Error::<Runtime>::NumOverflow
 		);
 	});
@@ -189,29 +197,33 @@ fn claim_works() {
 			period_count: 2u32,
 			per_period: 10u64,
 		};
-		assert_ok!(Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, schedule));
+		assert_ok!(Vesting::add_vesting_schedule(
+			Origin::signed(ALICE::get()),
+			BOB::get(),
+			schedule
+		));
 
 		System::set_block_number(11);
 		// remain locked if not claimed
-		assert!(PalletBalances::transfer(Origin::signed(BOB), ALICE, 10).is_err());
+		assert!(PalletBalances::transfer(Origin::signed(BOB::get()), ALICE::get(), 10).is_err());
 		// unlocked after claiming
-		assert_ok!(Vesting::claim(Origin::signed(BOB)));
-		assert_ok!(PalletBalances::transfer(Origin::signed(BOB), ALICE, 10));
+		assert_ok!(Vesting::claim(Origin::signed(BOB::get())));
+		assert_ok!(PalletBalances::transfer(Origin::signed(BOB::get()), ALICE::get(), 10));
 		// more are still locked
-		assert!(PalletBalances::transfer(Origin::signed(BOB), ALICE, 1).is_err());
+		assert!(PalletBalances::transfer(Origin::signed(BOB::get()), ALICE::get(), 1).is_err());
 		// does not clear storage
-		assert!(<VestingSchedules<Runtime>>::contains_key(BOB));
+		assert!(<VestingSchedules<Runtime>>::contains_key(BOB::get()));
 
 		System::set_block_number(21);
 		// claim more
-		assert_ok!(Vesting::claim(Origin::signed(BOB)));
-		assert_ok!(PalletBalances::transfer(Origin::signed(BOB), ALICE, 10));
+		assert_ok!(Vesting::claim(Origin::signed(BOB::get())));
+		assert_ok!(PalletBalances::transfer(Origin::signed(BOB::get()), ALICE::get(), 10));
 		// all used up
-		assert_eq!(PalletBalances::free_balance(BOB), 0);
+		assert_eq!(PalletBalances::free_balance(BOB::get()), 0);
 		// clears the storage
-		assert!(!<VestingSchedules<Runtime>>::contains_key(BOB));
+		assert!(!<VestingSchedules<Runtime>>::contains_key(BOB::get()));
 		// no locks anymore
-		assert_eq!(PalletBalances::locks(&BOB), vec![]);
+		assert_eq!(PalletBalances::locks(&BOB::get()), vec![]);
 	});
 }
 
@@ -219,7 +231,7 @@ fn claim_works() {
 fn cancel_restricted_origin() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_noop!(
-			Vesting::cancel_all_vesting_schedules(Origin::signed(ALICE), BOB, CancelOrigin::get()),
+			Vesting::cancel_all_vesting_schedules(Origin::signed(ALICE::get()), BOB::get(), CancelOrigin::get()),
 			BadOrigin
 		);
 	})
@@ -234,21 +246,29 @@ fn cancel_auto_claim_recipient_funds_and_wire_the_rest() {
 			period_count: 2u32,
 			per_period: 10u64,
 		};
-		assert_ok!(Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, schedule));
+		assert_ok!(Vesting::add_vesting_schedule(
+			Origin::signed(ALICE::get()),
+			BOB::get(),
+			schedule
+		));
 
 		System::set_block_number(11);
 
 		assert_ok!(Vesting::cancel_all_vesting_schedules(
 			Origin::signed(CancelOrigin::get()),
-			BOB,
+			BOB::get(),
 			CancelOrigin::get()
 		));
 
 		// Auto claim
-		assert_ok!(PalletBalances::transfer(Origin::signed(BOB), ALICE, 10));
+		assert_ok!(PalletBalances::transfer(Origin::signed(BOB::get()), ALICE::get(), 10));
 
 		// Wire the rest
-		assert_ok!(PalletBalances::transfer(Origin::signed(CancelOrigin::get()), ALICE, 10));
+		assert_ok!(PalletBalances::transfer(
+			Origin::signed(CancelOrigin::get()),
+			ALICE::get(),
+			10
+		));
 	});
 }
 
@@ -261,17 +281,21 @@ fn cancel_clears_storage() {
 			period_count: 2u32,
 			per_period: 10u64,
 		};
-		assert_ok!(Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, schedule));
+		assert_ok!(Vesting::add_vesting_schedule(
+			Origin::signed(ALICE::get()),
+			BOB::get(),
+			schedule
+		));
 
 		System::set_block_number(11);
 
 		assert_ok!(Vesting::cancel_all_vesting_schedules(
 			Origin::signed(CancelOrigin::get()),
-			BOB,
+			BOB::get(),
 			CancelOrigin::get()
 		));
 
-		assert!(!<VestingSchedules<Runtime>>::contains_key(BOB));
+		assert!(!<VestingSchedules<Runtime>>::contains_key(BOB::get()));
 	});
 }
 
@@ -285,10 +309,47 @@ fn cancel_tolerates_corrupted_state() {
 			per_period: 10u64,
 		};
 
-		assert!(!<VestingSchedules<Runtime>>::contains_key(BOB));
-		let ans = Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, allice_vesting_to_bob_schedule.clone());
+		// Initial Balance Status
+		assert_eq!(mock::balances(&ALICE::get()), (100, 0));
+		assert_eq!(PalletBalances::total_balance(&ALICE::get()), 100);
+
+		assert_eq!(mock::balances(&BOB::get()), (0, 0));
+		assert_eq!(PalletBalances::total_balance(&BOB::get()), 0);
+
+		assert_eq!(mock::balances(&CancelOrigin::get()), (0, 0));
+		assert_eq!(PalletBalances::total_balance(&CancelOrigin::get()), 0);
+
+		assert!(!<VestingSchedules<Runtime>>::contains_key(BOB::get()));
+
+		let ans = Vesting::add_vesting_schedule(
+			Origin::signed(ALICE::get()),
+			BOB::get(),
+			allice_vesting_to_bob_schedule.clone(),
+		);
 		assert_ok!(ans);
-		assert!(<VestingSchedules<Runtime>>::contains_key(BOB));
+		assert!(<VestingSchedules<Runtime>>::contains_key(BOB::get()));
+
+		// Event & Balance Status
+		let mut expected = vec![Event::VestingScheduleAdded(
+			ALICE::get(),
+			BOB::get(),
+			VestingSchedule {
+				start: 0,
+				period: 10,
+				period_count: 2,
+				per_period: 10,
+			},
+		)];
+		assert_eq!(context_events(), expected);
+
+		assert_eq!(mock::balances(&ALICE::get()), (80, 0));
+		assert_eq!(PalletBalances::total_balance(&ALICE::get()), 80);
+
+		assert_eq!(mock::balances(&BOB::get()), (20, 20));
+		assert_eq!(PalletBalances::total_balance(&BOB::get()), 20);
+
+		assert_eq!(mock::balances(&CancelOrigin::get()), (0, 0));
+		assert_eq!(PalletBalances::total_balance(&CancelOrigin::get()), 0);
 
 		// We also add some vesting schedules without any balances to simulate
 		// a corrupted / badly canceled state.
@@ -306,9 +367,9 @@ fn cancel_tolerates_corrupted_state() {
 		});
 		assert_ok!(ans);
 
-		assert!(<VestingSchedules<Runtime>>::contains_key(BOB));
+		assert!(<VestingSchedules<Runtime>>::contains_key(BOB::get()));
 
-		if let Ok(schedule_from_chain) = <VestingSchedules<Runtime>>::try_get(BOB) {
+		if let Ok(schedule_from_chain) = <VestingSchedules<Runtime>>::try_get(BOB::get()) {
 			assert_eq!(schedule_from_chain.len(), 2);
 
 			assert_eq!(schedule_from_chain[0], allice_vesting_to_bob_schedule);
@@ -318,13 +379,27 @@ fn cancel_tolerates_corrupted_state() {
 		}
 
 		System::set_block_number(11);
-		assert!(<VestingSchedules<Runtime>>::contains_key(BOB));
+		assert!(<VestingSchedules<Runtime>>::contains_key(BOB::get()));
 
 		let res_cancel_all_vesting_schedules =
-			Vesting::cancel_all_vesting_schedules(Origin::signed(CancelOrigin::get()), BOB, CancelOrigin::get());
+			Vesting::cancel_all_vesting_schedules(Origin::signed(CancelOrigin::get()), BOB::get(), CancelOrigin::get());
 		assert_ok!(res_cancel_all_vesting_schedules);
 
-		assert!(!<VestingSchedules<Runtime>>::contains_key(BOB));
+		assert!(!<VestingSchedules<Runtime>>::contains_key(BOB::get()));
+
+		// Event & Balance Status
+		expected.append(&mut vec![Event::VestingSchedulesCanceled(2)]);
+
+		assert_eq!(context_events(), expected);
+
+		assert_eq!(mock::balances(&ALICE::get()), (80, 0));
+		assert_eq!(PalletBalances::total_balance(&ALICE::get()), 80);
+
+		assert_eq!(mock::balances(&BOB::get()), (0, 0));
+		assert_eq!(PalletBalances::total_balance(&BOB::get()), 0);
+
+		assert_eq!(mock::balances(&CancelOrigin::get()), (20, 0));
+		assert_eq!(PalletBalances::total_balance(&CancelOrigin::get()), 20);
 	});
 }
 
@@ -333,8 +408,8 @@ fn cannot_vest_to_self() {
 	ExtBuilder::default().one_hundred_for_alice().build().execute_with(|| {
 		assert_noop!(
 			Vesting::add_vesting_schedule(
-				Origin::signed(ALICE),
-				ALICE,
+				Origin::signed(ALICE::get()),
+				ALICE::get(),
 				VestingSchedule {
 					start: 0u64,
 					period: 10u64,
@@ -350,7 +425,7 @@ fn cannot_vest_to_self() {
 #[test]
 fn add_vesting_schedule_overflow_check() {
 	ExtBuilder::default()
-		.balances(vec![(ALICE, 1000)])
+		.balances(vec![(ALICE::get(), 1000)])
 		.build()
 		.execute_with(|| {
 			System::set_block_number(1);
@@ -377,22 +452,22 @@ fn add_vesting_schedule_overflow_check() {
 			];
 
 			assert_ok!(Vesting::add_vesting_schedule(
-				Origin::signed(ALICE),
-				BOB,
+				Origin::signed(ALICE::get()),
+				BOB::get(),
 				schedules[0].clone(),
 			));
-			assert_eq!(Vesting::vesting_schedules(&BOB).to_vec().len(), 1);
+			assert_eq!(Vesting::vesting_schedules(&BOB::get()).to_vec().len(), 1);
 
 			let expected = vec![Event::VestingScheduleAdded(1, 2, schedules[0].clone())];
 
 			assert_eq!(context_events(), expected);
 
 			assert_ok!(Vesting::add_vesting_schedule(
-				Origin::signed(ALICE),
-				BOB,
+				Origin::signed(ALICE::get()),
+				BOB::get(),
 				schedules[1].clone(),
 			));
-			assert_eq!(Vesting::vesting_schedules(&BOB).to_vec().len(), 2);
+			assert_eq!(Vesting::vesting_schedules(&BOB::get()).to_vec().len(), 2);
 
 			let expected = vec![
 				Event::VestingScheduleAdded(1, 2, schedules[0].clone()),
@@ -402,18 +477,18 @@ fn add_vesting_schedule_overflow_check() {
 			assert_eq!(context_events(), expected);
 
 			assert_err!(
-				Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, schedules[2].clone(),),
+				Vesting::add_vesting_schedule(Origin::signed(ALICE::get()), BOB::get(), schedules[2].clone(),),
 				<Error<Runtime>>::MaxScheduleOverflow,
 			);
 
-			assert_eq!(Vesting::vesting_schedules(&BOB).to_vec().len(), 2);
+			assert_eq!(Vesting::vesting_schedules(&BOB::get()).to_vec().len(), 2);
 		});
 }
 
 #[test]
 fn add_vesting_schedule_overflow_cfg_min_check() {
 	ExtBuilder::default()
-		.balances(vec![(ALICE, 1000)])
+		.balances(vec![(ALICE::get(), 1000)])
 		.build()
 		.execute_with(|| {
 			System::set_block_number(1);
@@ -427,14 +502,14 @@ fn add_vesting_schedule_overflow_cfg_min_check() {
 
 			mock::MAX_SCHEDULE.with(|v| *v.borrow_mut() = 0);
 
-			assert_eq!(Vesting::vesting_schedules(&BOB).to_vec().len(), 0);
+			assert_eq!(Vesting::vesting_schedules(&BOB::get()).to_vec().len(), 0);
 
 			assert_err!(
-				Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, schedules[0].clone(),),
+				Vesting::add_vesting_schedule(Origin::signed(ALICE::get()), BOB::get(), schedules[0].clone(),),
 				<Error<Runtime>>::MaxScheduleOverflow,
 			);
 
-			assert_eq!(Vesting::vesting_schedules(&BOB).to_vec().len(), 0);
+			assert_eq!(Vesting::vesting_schedules(&BOB::get()).to_vec().len(), 0);
 
 			let expected = vec![];
 			assert_eq!(context_events(), expected);
@@ -442,11 +517,11 @@ fn add_vesting_schedule_overflow_cfg_min_check() {
 			mock::MAX_SCHEDULE.with(|v| *v.borrow_mut() = 1);
 
 			assert_ok!(Vesting::add_vesting_schedule(
-				Origin::signed(ALICE),
-				BOB,
+				Origin::signed(ALICE::get()),
+				BOB::get(),
 				schedules[0].clone(),
 			));
-			assert_eq!(Vesting::vesting_schedules(&BOB).to_vec().len(), 1);
+			assert_eq!(Vesting::vesting_schedules(&BOB::get()).to_vec().len(), 1);
 
 			let expected = vec![Event::VestingScheduleAdded(1, 2, schedules[0].clone())];
 
@@ -457,7 +532,7 @@ fn add_vesting_schedule_overflow_cfg_min_check() {
 #[test]
 fn add_vesting_schedule_overflow_cfg_max_check() {
 	ExtBuilder::default()
-		.balances(vec![(ALICE, 10_000_000)])
+		.balances(vec![(ALICE::get(), 10_000_000)])
 		.build()
 		.execute_with(|| {
 			System::set_block_number(1);
@@ -475,20 +550,26 @@ fn add_vesting_schedule_overflow_cfg_max_check() {
 
 			(0..schedule_max).into_iter().for_each(|iter_index| {
 				assert_ok!(Vesting::add_vesting_schedule(
-					Origin::signed(ALICE),
-					BOB,
+					Origin::signed(ALICE::get()),
+					BOB::get(),
 					schedules[0].clone(),
 				));
-				assert_eq!(Vesting::vesting_schedules(&BOB).to_vec().len() as u32, iter_index + 1);
+				assert_eq!(
+					Vesting::vesting_schedules(&BOB::get()).to_vec().len() as u32,
+					iter_index + 1
+				);
 				assert_eq!(context_events().len() as u32, iter_index + 1);
 			});
 
 			assert_err!(
-				Vesting::add_vesting_schedule(Origin::signed(ALICE), BOB, schedules[0].clone(),),
+				Vesting::add_vesting_schedule(Origin::signed(ALICE::get()), BOB::get(), schedules[0].clone(),),
 				<Error<Runtime>>::MaxScheduleOverflow,
 			);
 
-			assert_eq!(Vesting::vesting_schedules(&BOB).to_vec().len(), schedule_max as usize);
+			assert_eq!(
+				Vesting::vesting_schedules(&BOB::get()).to_vec().len(),
+				schedule_max as usize
+			);
 			assert_eq!(context_events().len(), schedule_max as usize);
 		});
 }

--- a/pallets/grants/src/tests.rs
+++ b/pallets/grants/src/tests.rs
@@ -353,17 +353,15 @@ fn cancel_tolerates_corrupted_state() {
 
 		// We also add some vesting schedules without any balances to simulate
 		// a corrupted / badly canceled state.
-		assert_ok!(<VestingSchedules<Runtime>>::try_mutate(BOB, |s| -> Result<(), ()> {
-			let _ = s
-				.try_push(VestingSchedule {
-					start: 0u64,
-					period: 10u64,
-					period_count: 2u32,
-					per_period: 1_000u64, // definitely too much money
-				})
-				.map_err(|err| {
-					log::error!("Exceeds vesting schedule max: {:#?}", err);
-				});
+		let bob_modified_vesting_schedule = VestingSchedule {
+			start: 0u64,
+			period: 10u64,
+			period_count: 2u32,
+			per_period: 1_000u64, // definitely too much money
+		};
+
+		let ans = <VestingSchedules<Runtime>>::try_mutate(BOB::get(), |s| -> Result<(), ()> {
+			s.try_push(bob_modified_vesting_schedule.clone())
 		});
 		assert_ok!(ans);
 
@@ -375,8 +373,7 @@ fn cancel_tolerates_corrupted_state() {
 			assert_eq!(schedule_from_chain[0], allice_vesting_to_bob_schedule);
 			assert_eq!(schedule_from_chain[1], bob_modified_vesting_schedule);
 		} else {
-			#[cfg_attr(tarpaulin, ignore)]
-			panic!("Code expected to be dead is alive");
+			assert!(false, "Expected Bob to have some grants, Got error instead");
 		}
 
 		System::set_block_number(11);

--- a/pallets/staking/src/benchmarking.rs
+++ b/pallets/staking/src/benchmarking.rs
@@ -18,6 +18,7 @@
 
 #![cfg(feature = "runtime-benchmarks")]
 #![allow(unused)]
+#![cfg_attr(tarpaulin, ignore)]
 
 use super::*;
 

--- a/runtimes/eden/src/pallets_nodle.rs
+++ b/runtimes/eden/src/pallets_nodle.rs
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 use crate::{
-	constants, pallets_governance::MoreThanHalfOfTechComm, Allocations, Balances, CompanyReserve, Event, Runtime,
+	constants, pallets_governance::MoreThanHalfOfTechComm, AllocationsOracles, Balances, CompanyReserve, Event, Runtime,
 };
 use frame_support::{parameter_types, PalletId};
 use primitives::Balance;
@@ -37,6 +37,7 @@ impl pallet_allocations::Config for Runtime {
 	type MaximumSupply = MaximumSupply;
 	type ExistentialDeposit = <Runtime as pallet_balances::Config>::ExistentialDeposit;
 	type MaxAllocs = MaxAllocs;
+	type OracleMembers = AllocationsOracles;
 	type WeightInfo = pallet_allocations::weights::SubstrateWeight<Runtime>;
 }
 
@@ -51,8 +52,8 @@ impl pallet_membership::Config<pallet_membership::Instance2> for Runtime {
 	type SwapOrigin = MoreThanHalfOfTechComm;
 	type ResetOrigin = MoreThanHalfOfTechComm;
 	type PrimeOrigin = MoreThanHalfOfTechComm;
-	type MembershipInitialized = Allocations;
-	type MembershipChanged = Allocations;
+	type MembershipInitialized = ();
+	type MembershipChanged = ();
 	type MaxMembers = MaxMembers;
 	type WeightInfo = pallet_membership::weights::SubstrateWeight<Runtime>;
 }

--- a/runtimes/eden/src/pallets_util.rs
+++ b/runtimes/eden/src/pallets_util.rs
@@ -31,11 +31,16 @@ use frame_system::{EnsureRoot, EnsureSigned};
 use primitives::{AccountId, Balance};
 use sp_runtime::Perbill;
 
+parameter_types! {
+	pub const MaxSchedule: u32 = 20;
+}
+
 impl pallet_grants::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
 	type CancelOrigin = MoreThanHalfOfTechComm;
 	type ForceOrigin = MoreThanHalfOfTechComm;
+	type MaxSchedule = MaxSchedule;
 	type WeightInfo = pallet_grants::weights::SubstrateWeight<Runtime>;
 	type BlockNumberProvider = RelayChainBlockNumberProvider<Runtime>;
 }

--- a/runtimes/eden/src/pallets_util.rs
+++ b/runtimes/eden/src/pallets_util.rs
@@ -32,7 +32,7 @@ use primitives::{AccountId, Balance};
 use sp_runtime::Perbill;
 
 parameter_types! {
-	pub const MaxSchedule: u32 = 20;
+	pub const MaxSchedule: u32 = 100;
 }
 
 impl pallet_grants::Config for Runtime {


### PR DESCRIPTION
Part of [#173](https://github.com/NodleCode/chain-workspace/issues/173)

**HighLights**

- Storage `VestingSchedules` is moved to bounded vector.
- Upperlimit  for  `VestingSchedules`  is Configured via `MaxSchedule`.
- Introduce error code `MaxScheduleOverflow`.
- UnitTest Extension :: Done
- Runtime Integration :: Done
- Storage Migration (try_runtime) :: Done
- Benchmarking

**TODO**

**Ready for Intake Review**