### PR TITLE
review uniques economics

### DIFF
--- a/runtimes/eden/src/pallets_util.rs
+++ b/runtimes/eden/src/pallets_util.rs
@@ -110,10 +110,10 @@ impl pallet_preimage::Config for Runtime {
 }
 
 parameter_types! {
-	pub const ClassDeposit: Balance = 10 * constants::NODL;
-	pub const InstanceDeposit: Balance = 100 * constants::MILLI_NODL;
-	pub const MetadataDepositBase: Balance = 10 * constants::NODL;
-	pub const MetadataDepositPerByte: Balance = 1 * constants::NODL;
+	pub const ClassDeposit: Balance = 20 * constants::NODL;
+	pub const InstanceDeposit: Balance = 1 * constants::NODL;
+	pub const MetadataDepositBase: Balance = 2 * constants::NODL;
+	pub const MetadataDepositPerByte: Balance = 10 * constants::MILLI_NODL;
 	pub const KeyLimit: u32 = 32;
 	pub const ValueLimit: u32 = 256;
 	pub const StringLimit: u32 = 50;


### PR DESCRIPTION
**Would this be merged, we need a deployment before the end of the month for our event.**

## Details
Modify base fees for the `uniques` pallet:
- make it slightly more expensive to create a new class
- make it slightly more expensive to create a new instance
- make it much cheaper to register metadatas (base and per byte fee)

The goal here is to make the fees make a bit more sense when creating big collections while ensuring we still maintain economic consistency.

### Before
- creating a class with metadata: $ c_{class} = 10 + 10 + 46*1 = 66 $
- creating one instance with metadata: $ c_{instance} = 0.1 + 10 + 46*1 = 56.1 $

Creating a collection of 50k NFTs with a metadata size of 46 bytes (IPFS CID) will cost: $ c_{class} + 50,000*c_{instance} = 66 + 50,000*56.1 = 2,805,066 $
This seems like a lot for just 50k NFTs!

### After
- creating a class with metadata: $ c_{class} = 20 + 2 + 46*0.01 = 22.46 $
- creating one instance with metadata: $ c_{instance} = 1 + 2 + 46*0.01 = 3.46 $

Creating a collection of 50k NFTs with a metadata size of 46 bytes (IPFS CID) will cost: $ c_{class} + 50,000*c_{instance} = 22.46 + 50,000*3.46 = 173,022.46 $
Which could be more acceptable, depending on the NODL market price of course :smile:.