### PR TITLE
dao reserve

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -159,6 +159,9 @@ fn eden_testnet_genesis(
 
 		// Allocations
 		allocations_oracles: Default::default(),
+
+		// DAO
+		dao_reserve: Default::default(),
 	}
 }
 

--- a/runtimes/eden/src/lib.rs
+++ b/runtimes/eden/src/lib.rs
@@ -117,6 +117,9 @@ construct_runtime! {
 		// EmergencyShutdown: pallet_emergency_shutdown = 50,
 		Allocations: pallet_allocations = 51,
 		AllocationsOracles: pallet_membership::<Instance2> = 52,
+
+		// DAO
+		DaoReserve: pallet_reserve::<Instance4> = 60,
 	}
 }
 

--- a/runtimes/eden/src/pallets_governance.rs
+++ b/runtimes/eden/src/pallets_governance.rs
@@ -18,7 +18,7 @@
 
 use crate::{constants, Call, Event, Origin, Runtime, TechnicalCommittee};
 use frame_support::{parameter_types, traits::EitherOfDiverse, PalletId};
-use frame_system::EnsureRoot;
+use frame_system::{EnsureNever, EnsureRoot};
 use primitives::{AccountId, BlockNumber};
 pub use sp_runtime::{Perbill, Perquintill};
 
@@ -68,9 +68,9 @@ parameter_types! {
 impl pallet_reserve::Config<pallet_reserve::Instance4> for Runtime {
 	type Event = Event;
 	type Currency = pallet_balances::Pallet<Runtime>;
-	// as of now only root can spend this, later, we need to map this to the
+	// as of now nobody can spend this, later, we need to map this to the
 	// correct governance origin.
-	type ExternalOrigin = EnsureRoot<AccountId>;
+	type ExternalOrigin = EnsureNever<AccountId>;
 	type Call = Call;
 	type PalletId = DaoReservePalletId;
 	type WeightInfo = pallet_reserve::weights::SubstrateWeight<Runtime>;

--- a/runtimes/eden/src/pallets_governance.rs
+++ b/runtimes/eden/src/pallets_governance.rs
@@ -62,6 +62,21 @@ impl pallet_reserve::Config<pallet_reserve::Instance3> for Runtime {
 }
 
 parameter_types! {
+	pub const DaoReservePalletId: PalletId = PalletId(*b"py/nddao"); // 5EYCAe5ijiYfABcws2T5dgN35iWYaWwvh8wPgbZaBKRRpMzV
+}
+
+impl pallet_reserve::Config<pallet_reserve::Instance4> for Runtime {
+	type Event = Event;
+	type Currency = pallet_balances::Pallet<Runtime>;
+	// as of now only root can spend this, later, we need to map this to the
+	// correct governance origin.
+	type ExternalOrigin = EnsureRoot<AccountId>;
+	type Call = Call;
+	type PalletId = DaoReservePalletId;
+	type WeightInfo = pallet_reserve::weights::SubstrateWeight<Runtime>;
+}
+
+parameter_types! {
 	pub const MotionDuration: BlockNumber = 2 * constants::DAYS;
 	pub const MaxProposals: u32 = 100;
 	pub const MaxMembers: u32 = 50;

--- a/runtimes/eden/src/version.rs
+++ b/runtimes/eden/src/version.rs
@@ -39,7 +39,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	/// Version of the runtime specification. A full-node will not attempt to use its native
 	/// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
 	/// `spec_version` and `authoring_version` are the same between Wasm and native.
-	spec_version: 13,
+	spec_version: 14,
 
 	/// Version of the implementation of the specification. Nodes are free to ignore this; it
 	/// serves only as an indication that the code is different; as long as the other two versions


### PR DESCRIPTION
Explicitly create a dao reserve for future plumbing in the code. Marked as
`EnsureNever` so that nobody can use it (yet).
