### PR TITLE
build: fix srtool build

### DIFF
--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - aliX/fix-srtool-build
     pull_request:
 
 jobs:

--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - aliX/fix-srtool-build
     pull_request:
 
 jobs:
@@ -23,7 +24,6 @@ jobs:
           chain: ${{ matrix.runtime }}
           package: runtime-${{ matrix.runtime }}
           runtime_dir: runtimes/${{ matrix.runtime }}
-          tag: 1.60.0
 
       - name: Summary
         run: |


### PR DESCRIPTION
I tested the change here: https://github.com/NodleCode/chain/actions/runs/3086849701. Without it we would get:

>  error[E0658]: use of unstable library feature 'vec_retain_mut'
>  --> /cargo-home/git/checkouts/substrate-7e08433d4c370a21/34a0621/client/transaction-pool/src/graph/validated_pool.rs:207:12
>  |
>  207 | sinks.retain_mut(|sink| match sink.try_send(*hash) {
>  | ^^^^^^^^^^
>  |
>  = note: see issue #90829 <https://github.com/rust-lang/rust/issues/90829> for more information
>  = help: add `#![feature(vec_retain_mut)]` to the crate attributes to enable