### PR TITLE
fix: allocations access to the relay chain block number

### DIFF
--- a/pallets/allocations/src/benchmarking.rs
+++ b/pallets/allocations/src/benchmarking.rs
@@ -60,7 +60,6 @@ benchmarks! {
 		let mut members = <BenchmarkOracles<T>>::get();
 		assert!(members.try_push(oracle.clone()).is_ok());
 		<BenchmarkOracles<T>>::put(&members);
-		<Allocations<T>>::checked_update_session_quota();
 		<SessionQuota<T>>::put(T::ExistentialDeposit::get() * (b * ALLOC_FACTOR).into());
 	}:{
 		let _ = Allocations::<T>::allocate(batch_arg);
@@ -80,6 +79,14 @@ benchmarks! {
 	}
 	verify {
 		assert_last_event::<T>(Event::SessionQuotaRenewed.into())
+	}
+
+	checked_update_session_quota {
+	}:{
+		Allocations::<T>::checked_update_session_quota();
+	}
+	verify {
+		assert_eq!(frame_system::Pallet::<T>::events().len(), 2);
 	}
 
 	set_curve_starting_block {

--- a/pallets/allocations/src/benchmarking.rs
+++ b/pallets/allocations/src/benchmarking.rs
@@ -60,20 +60,21 @@ benchmarks! {
 		let mut members = <BenchmarkOracles<T>>::get();
 		assert!(members.try_push(oracle.clone()).is_ok());
 		<BenchmarkOracles<T>>::put(&members);
+		<Allocations<T>>::checked_update_session_quota();
 		<SessionQuota<T>>::put(T::ExistentialDeposit::get() * (b * ALLOC_FACTOR).into());
 	}: _(RawOrigin::Signed(oracle), batch_arg)
 
 	calc_quota {
 	}: {
-		Allocations::<T>::checked_calc_session_quota(Zero::zero(), true);
+		Allocations::<T>::checked_calc_session_quota(Zero::zero());
 	}
 	verify {
-		assert_last_event::<T>(Event::SessionQuotaCalculated(<NextSessionQuota<T>>::get().unwrap()).into())
+		assert_last_event::<T>(Event::SessionQuotaCalculated(<NextSessionQuota<T>>::get()).into())
 	}
 
 	renew_quota {
 	}: {
-		Allocations::<T>::checked_renew_session_quota(Zero::zero(), true);
+		Allocations::<T>::checked_renew_session_quota(Zero::zero());
 	}
 	verify {
 		assert_last_event::<T>(Event::SessionQuotaRenewed.into())

--- a/pallets/allocations/src/benchmarking.rs
+++ b/pallets/allocations/src/benchmarking.rs
@@ -52,7 +52,7 @@ fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
 }
 
 benchmarks! {
-	batch {
+	allocate {
 		let b in 1..T::MaxAllocs::get();
 
 		let batch_arg = make_batch::<T>(b);
@@ -62,7 +62,9 @@ benchmarks! {
 		<BenchmarkOracles<T>>::put(&members);
 		<Allocations<T>>::checked_update_session_quota();
 		<SessionQuota<T>>::put(T::ExistentialDeposit::get() * (b * ALLOC_FACTOR).into());
-	}: _(RawOrigin::Signed(oracle), batch_arg)
+	}:{
+		let _ = Allocations::<T>::allocate(batch_arg);
+	}
 
 	calc_quota {
 	}: {

--- a/pallets/allocations/src/lib.rs
+++ b/pallets/allocations/src/lib.rs
@@ -212,7 +212,7 @@ pub mod pallet {
 		/// Optimized allocation call, which will batch allocations of various amounts
 		/// and destinations and together. This allow us to be much more efficient and thus
 		/// increase our chain's capacity in handling these transactions.
-		#[pallet::weight(<T as pallet::Config>::WeightInfo::allocate(rewards.len().try_into().unwrap_or_else(|_| T::MaxAllocs::get())))]
+		#[pallet::weight(T::WeightInfo::allocate(rewards.len().try_into().unwrap_or_else(|_| T::MaxAllocs::get())).saturating_add(T::WeightInfo::checked_update_session_quota()))]
 		pub fn batch(
 			origin: OriginFor<T>,
 			rewards: BoundedVec<(T::AccountId, BalanceOf<T>), T::MaxAllocs>,
@@ -376,7 +376,7 @@ impl<T: Config> Pallet<T> {
 	/// Return the weight of the call.
 	fn checked_update_session_quota() -> Weight {
 		let n = T::BlockNumberProvider::current_block_number();
-		// Storage: System Number (r:1 w:0)
+		// Storage: ParachainSystem ValidationData (r:1 w:0)
 		let read_block_number_weight = T::DbWeight::get().reads(1 as Weight);
 
 		let calc_quota_weight = Self::checked_calc_session_quota(n);

--- a/pallets/allocations/src/lib.rs
+++ b/pallets/allocations/src/lib.rs
@@ -212,15 +212,15 @@ pub mod pallet {
 		/// Optimized allocation call, which will batch allocations of various amounts
 		/// and destinations and together. This allow us to be much more efficient and thus
 		/// increase our chain's capacity in handling these transactions.
-		#[pallet::weight(T::WeightInfo::allocate(rewards.len().try_into().unwrap_or_else(|_| T::MaxAllocs::get())).saturating_add(T::WeightInfo::checked_update_session_quota()))]
+		#[pallet::weight(T::WeightInfo::allocate(batch.len().try_into().unwrap_or_else(|_| T::MaxAllocs::get())).saturating_add(T::WeightInfo::checked_update_session_quota()))]
 		pub fn batch(
 			origin: OriginFor<T>,
-			rewards: BoundedVec<(T::AccountId, BalanceOf<T>), T::MaxAllocs>,
+			batch: BoundedVec<(T::AccountId, BalanceOf<T>), T::MaxAllocs>,
 		) -> DispatchResultWithPostInfo {
 			Self::ensure_oracle(origin)?;
 			let update_weight = Self::checked_update_session_quota();
-			let rewards_len = rewards.len().try_into().unwrap_or_else(|_| T::MaxAllocs::get());
-			Self::allocate(rewards)?;
+			let rewards_len = batch.len().try_into().unwrap_or_else(|_| T::MaxAllocs::get());
+			Self::allocate(batch)?;
 			let dispatch_info = PostDispatchInfo::from((
 				Some(update_weight.saturating_add(T::WeightInfo::allocate(rewards_len))),
 				Pays::No,

--- a/pallets/allocations/src/tests.rs
+++ b/pallets/allocations/src/tests.rs
@@ -562,6 +562,30 @@ fn only_root_can_set_curve_starting_block() {
 }
 
 #[test]
+fn very_first_batch_call_sets_curve_starting_block() {
+	new_test_ext().execute_with(|| {
+		assert_eq!(<MintCurveStartingBlock<Test>>::get(), None);
+		System::set_block_number(5);
+		let _issuance = Balances::issue(100000u64);
+		assert_ok!(Allocations::batch(
+			Origin::signed(Oracle::get()),
+			bounded_vec![(Grantee::get(), 50)]
+		));
+		assert_eq!(<MintCurveStartingBlock<Test>>::get(), Some(5));
+		assert_eq!(<SessionQuotaCalculationSchedule<Test>>::get(), 15);
+		assert_eq!(<SessionQuotaRenewSchedule<Test>>::get(), 8);
+		System::set_block_number(6);
+		assert_ok!(Allocations::batch(
+			Origin::signed(Oracle::get()),
+			bounded_vec![(Grantee::get(), 50)]
+		));
+		assert_eq!(<MintCurveStartingBlock<Test>>::get(), Some(5));
+		assert_eq!(<SessionQuotaCalculationSchedule<Test>>::get(), 15);
+		assert_eq!(<SessionQuotaRenewSchedule<Test>>::get(), 8);
+	})
+}
+
+#[test]
 fn simple_allocation_works() {
 	new_test_ext().execute_with(|| {
 		let total_issuance = 100000u64;

--- a/pallets/allocations/src/tests.rs
+++ b/pallets/allocations/src/tests.rs
@@ -538,10 +538,9 @@ fn oracle_does_not_pay_fees() {
 	new_test_ext().execute_with(|| {
 		let total_issuance = 100000u64;
 		let _issuance = Balances::issue(total_issuance);
-		assert_eq!(
-			Allocations::batch(Origin::signed(Oracle::get()), bounded_vec![(Grantee::get(), 50)]),
-			Ok(Pays::No.into())
-		);
+		let result = Allocations::batch(Origin::signed(Oracle::get()), bounded_vec![(Grantee::get(), 50)])
+			.expect("batch call failed");
+		assert_eq!(result.pays_fee, Pays::No);
 	})
 }
 

--- a/pallets/allocations/src/tests.rs
+++ b/pallets/allocations/src/tests.rs
@@ -22,7 +22,7 @@ use super::*;
 use crate::{self as pallet_allocations};
 use frame_support::{
 	assert_noop, assert_ok, bounded_vec, ord_parameter_types, parameter_types,
-	traits::{ConstU32, GenesisBuild, Hooks},
+	traits::{ConstU32, GenesisBuild},
 	weights::Pays,
 	PalletId,
 };
@@ -195,11 +195,6 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	ext
 }
 
-fn on_finalize(n: u64) {
-	System::set_block_number(n);
-	Allocations::on_finalize(n);
-}
-
 #[test]
 fn mint_curve_direct_build() {
 	let curve = MintCurve::<Test> {
@@ -214,15 +209,15 @@ fn mint_curve_direct_build() {
 }
 
 #[test]
-fn inflation_step_0_is_used_for_0_fiscal_period_and_session_is_assumed_equal_to_fiscal() {
+fn assume_fiscal_period_0_is_infinitesimal() {
 	let curve = MintCurve::<Test> {
 		session_period: 3u64,
 		fiscal_period: 0u64,
 		inflation_steps: THREE_INFLATION_STEPS.to_vec(),
 		maximum_supply: 1_000_000u64,
 	};
-	assert_eq!(curve.checked_calc_next_session_quota(2, 1000u64, true), Some(10));
-	assert_eq!(curve.checked_calc_next_session_quota(3, 1000u64, true), Some(10));
+	assert_eq!(curve.calc_session_quota(2, 0, 1000u64), 5);
+	assert_eq!(curve.calc_session_quota(3, 0, 1000u64), 5);
 }
 
 #[test]
@@ -233,19 +228,7 @@ fn no_quota_for_0_session_period() {
 		inflation_steps: THREE_INFLATION_STEPS.to_vec(),
 		maximum_supply: 1_000_000u64,
 	};
-	assert_eq!(curve.checked_calc_next_session_quota(2, 1000u64, true), Some(0));
-}
-
-#[test]
-fn no_update_for_0_session_period() {
-	let curve = MintCurve::<Test> {
-		session_period: 0u64,
-		fiscal_period: 10u64,
-		inflation_steps: THREE_INFLATION_STEPS.to_vec(),
-		maximum_supply: 1_000_000u64,
-	};
-	assert_eq!(curve.should_update_session_quota(0), false);
-	assert_eq!(curve.should_update_session_quota(2), false);
+	assert_eq!(curve.calc_session_quota(2, 0, 1000u64), 0);
 }
 
 #[test]
@@ -266,85 +249,115 @@ fn mint_curve_maximum_supply() {
 }
 
 #[test]
-fn force_calc_next_session_quota() {
+fn calc_next_session_quota_for_all_inflation_steps() {
 	let curve = <MintCurve<Test>>::new(3u64, 10u64, THREE_INFLATION_STEPS, 1_000_000u64);
-	assert_eq!(curve.checked_calc_next_session_quota(7, 1000u64, false), None);
-	assert_eq!(curve.checked_calc_next_session_quota(7, 1000u64, true), Some(3));
-	assert_eq!(curve.checked_calc_next_session_quota(10, 1000u64, false), Some(6));
+	assert_eq!(curve.calc_session_quota(0, 0, 1000u64), 3);
+	assert_eq!(curve.calc_session_quota(10, 0, 1000u64), 6);
+	assert_eq!(curve.calc_session_quota(13, 3, 1000u64), 6);
+	assert_eq!(curve.calc_session_quota(20, 0, 1000u64), 1);
+	assert_eq!(curve.calc_session_quota(27, 7, 1000u64), 1);
+	assert_eq!(curve.calc_session_quota(30, 0, 1000u64), 1);
+	assert_eq!(curve.calc_session_quota(41, 11, 1000u64), 1);
 }
 
 #[test]
-fn calc_next_session_quota_for_all_inflation_steps() {
+fn sessions_before_curve_start_use_same_quota_as_in_first_inflation_step() {
 	let curve = <MintCurve<Test>>::new(3u64, 10u64, THREE_INFLATION_STEPS, 1_000_000u64);
-	assert_eq!(curve.checked_calc_next_session_quota(0, 1000u64, false), Some(3));
-	assert_eq!(curve.checked_calc_next_session_quota(10, 1000u64, false), Some(6));
-	assert_eq!(curve.checked_calc_next_session_quota(20, 1000u64, false), Some(1));
-	assert_eq!(curve.checked_calc_next_session_quota(30, 1000u64, false), Some(1));
-	assert_eq!(curve.checked_calc_next_session_quota(30, 1000u64, false), Some(1));
+	assert_eq!(curve.calc_session_quota(0, 37, 1000u64), 3);
+	assert_eq!(curve.calc_session_quota(10, 37, 1000u64), 3);
+	assert_eq!(curve.calc_session_quota(36, 37, 1000u64), 3);
+	assert_eq!(curve.calc_session_quota(37, 37, 1000u64), 3);
+	assert_eq!(curve.calc_session_quota(47, 37, 1000u64), 6);
+}
+
+#[test]
+fn next_schedule_before_curve_start() {
+	assert_eq!(<MintCurve<Test>>::next_schedule(0, 7, 3), 1);
+	assert_eq!(<MintCurve<Test>>::next_schedule(1, 7, 3), 4);
+	assert_eq!(<MintCurve<Test>>::next_schedule(2, 7, 3), 4);
+	assert_eq!(<MintCurve<Test>>::next_schedule(3, 7, 3), 4);
+	assert_eq!(<MintCurve<Test>>::next_schedule(4, 7, 3), 7);
+	assert_eq!(<MintCurve<Test>>::next_schedule(5, 7, 3), 7);
+	assert_eq!(<MintCurve<Test>>::next_schedule(6, 7, 3), 7);
+}
+
+#[test]
+fn next_schedule_after_curve_start() {
+	assert_eq!(<MintCurve<Test>>::next_schedule(7, 7, 3), 10);
+	assert_eq!(<MintCurve<Test>>::next_schedule(8, 7, 3), 10);
+	assert_eq!(<MintCurve<Test>>::next_schedule(9, 7, 3), 10);
+	assert_eq!(<MintCurve<Test>>::next_schedule(10, 7, 3), 13);
+	assert_eq!(<MintCurve<Test>>::next_schedule(11, 7, 3), 13);
+	assert_eq!(<MintCurve<Test>>::next_schedule(12, 7, 3), 13);
+	assert_eq!(<MintCurve<Test>>::next_schedule(36, 7, 3), 37);
+}
+
+#[test]
+fn next_schedule_when_period_is_0() {
+	assert_eq!(<MintCurve<Test>>::next_schedule(0, 7, 0), 7);
+	assert_eq!(<MintCurve<Test>>::next_schedule(6, 7, 0), 7);
+	assert_eq!(<MintCurve<Test>>::next_schedule(7, 7, 0), 7);
+	assert_eq!(<MintCurve<Test>>::next_schedule(8, 7, 0), 7);
+	assert_eq!(<MintCurve<Test>>::next_schedule(36, 7, 0), 7);
 }
 
 #[test]
 fn one_session_period_equals_one_fiscal_period_when_fiscal_is_zero() {
 	let curve = <MintCurve<Test>>::new(3u64, 0u64, THREE_INFLATION_STEPS, 1_000_000u64);
-	assert_eq!(curve.checked_calc_next_session_quota(2, 1000u64, true), Some(10));
-	assert_eq!(curve.checked_calc_next_session_quota(3, 1000u64, true), Some(20));
+	assert_eq!(curve.calc_session_quota(2, 0, 1000u64), 10);
+	assert_eq!(curve.calc_session_quota(3, 0, 1000u64), 20);
 }
 
 #[test]
 fn calc_next_session_quota_for_one_step_inflation() {
 	let curve = <MintCurve<Test>>::new(3u64, 10u64, ONE_INFLATION_STEP, 1_000_000u64);
-	assert_eq!(curve.checked_calc_next_session_quota(1, 1000u64, true), Some(3));
-	assert_eq!(curve.checked_calc_next_session_quota(10, 1000u64, true), Some(3));
-	assert_eq!(curve.checked_calc_next_session_quota(20, 1000u64, true), Some(3));
-	assert_eq!(curve.checked_calc_next_session_quota(32, 1000u64, true), Some(3));
+	assert_eq!(curve.calc_session_quota(1, 0, 1000u64), 3);
+	assert_eq!(curve.calc_session_quota(10, 0, 1000u64), 3);
+	assert_eq!(curve.calc_session_quota(20, 0, 1000u64), 3);
+	assert_eq!(curve.calc_session_quota(32, 0, 1000u64), 3);
 }
 
 #[test]
 fn calc_next_session_quota_when_no_inflation_is_configured() {
 	let curve = <MintCurve<Test>>::new(3u64, 10u64, NO_INFLATION_STEPS, 1_000_000u64);
-	assert_eq!(curve.checked_calc_next_session_quota(1, 1000u64, true), Some(0));
-	assert_eq!(curve.checked_calc_next_session_quota(10, 1000u64, true), Some(0));
-	assert_eq!(curve.checked_calc_next_session_quota(20, 1000u64, true), Some(0));
-	assert_eq!(curve.checked_calc_next_session_quota(32, 1000u64, true), Some(0));
+	assert_eq!(curve.calc_session_quota(1, 0, 1000u64), 0);
+	assert_eq!(curve.calc_session_quota(10, 0, 1000u64), 0);
+	assert_eq!(curve.calc_session_quota(20, 0, 1000u64), 0);
+	assert_eq!(curve.calc_session_quota(32, 0, 1000u64), 0);
 }
 
 #[test]
 fn calc_next_session_quota_when_inflation_is_zero() {
 	let curve = <MintCurve<Test>>::new(3u64, 10u64, ZERO_PERCENT_INFLATION_RATE, 1_000_000u64);
-	assert_eq!(curve.checked_calc_next_session_quota(1, 1000u64, true), Some(0));
+	assert_eq!(curve.calc_session_quota(1, 0, 1000u64), 0);
 }
 
 #[test]
 fn calc_next_session_quota_when_approaching_max_supply() {
 	let curve = <MintCurve<Test>>::new(10u64, 10u64, HUNDRED_PERCENT_INFLATION_RATE, 2000u64);
-	assert_eq!(curve.checked_calc_next_session_quota(1, 1000u64, true), Some(1000));
-	assert_eq!(curve.checked_calc_next_session_quota(1, 1100u64, true), Some(900));
+	assert_eq!(curve.calc_session_quota(1, 0, 1000u64), 1000);
+	assert_eq!(curve.calc_session_quota(1, 0, 1100u64), 900);
 	let curve = <MintCurve<Test>>::new(1u64, 9u64, HUNDRED_PERCENT_INFLATION_RATE, 2000u64);
-	assert_eq!(curve.checked_calc_next_session_quota(1, 1100u64, true), Some(100));
+	assert_eq!(curve.calc_session_quota(1, 0, 1100u64), 100);
 }
 
 #[test]
-fn should_update_session_quota() {
-	let curve = <MintCurve<Test>>::new(3u64, 10u64, THREE_INFLATION_STEPS, 1_000_000u64);
-	assert!(!curve.should_update_session_quota(2));
-	assert!(curve.should_update_session_quota(3));
-	assert!(curve.should_update_session_quota(15));
-	assert!(!curve.should_update_session_quota(17));
-}
-
-#[test]
-fn next_session_quota_is_initially_none() {
+fn next_session_quota_is_initially_0() {
 	new_test_ext().execute_with(|| {
-		assert_eq!(Allocations::next_session_quota(), None);
+		assert_eq!(Allocations::next_session_quota(), 0);
 	})
 }
 
 #[test]
 fn both_session_events_are_emitted_on_the_very_first_on_initialize_after_upgrade() {
 	new_test_ext().execute_with(|| {
-		assert_eq!(Allocations::next_session_quota(), None);
+		assert_eq!(Allocations::next_session_quota(), 0);
+		let total_issuance = 100000u64;
+		let _issuance = Balances::issue(total_issuance);
+		let session_share = total_issuance * MINT_CURVE.session_period() / MINT_CURVE.fiscal_period();
+		let session_quota = THREE_INFLATION_STEPS[0] * session_share;
 		assert!(System::events().is_empty());
-		on_finalize(7); // Here any block number is ok
+		Allocations::checked_update_session_quota();
 		let events: Vec<_> = System::events()
 			.into_iter()
 			.map(|event_record| event_record.event)
@@ -352,7 +365,7 @@ fn both_session_events_are_emitted_on_the_very_first_on_initialize_after_upgrade
 		assert_eq!(
 			events,
 			vec![
-				Event::Allocations(crate::Event::SessionQuotaCalculated(0)),
+				Event::Allocations(crate::Event::SessionQuotaCalculated(session_quota)),
 				Event::Allocations(crate::Event::SessionQuotaRenewed)
 			]
 		);
@@ -362,10 +375,11 @@ fn both_session_events_are_emitted_on_the_very_first_on_initialize_after_upgrade
 #[test]
 fn no_events_if_not_at_the_beginning_of_a_session_or_a_fiscal_period() {
 	new_test_ext().execute_with(|| {
-		assert_eq!(Allocations::next_session_quota(), None);
-		on_finalize(7); // Here any block number is ok
+		System::set_block_number(7);
+		Allocations::checked_update_session_quota();
 		System::reset_events();
-		on_finalize(8);
+		System::set_block_number(8);
+		Allocations::checked_update_session_quota();
 		assert!(System::events().is_empty());
 	})
 }
@@ -373,9 +387,11 @@ fn no_events_if_not_at_the_beginning_of_a_session_or_a_fiscal_period() {
 #[test]
 fn emit_session_quota_renewed_at_the_beginning_of_a_session() {
 	new_test_ext().execute_with(|| {
-		on_finalize(7);
+		System::set_block_number(7);
+		Allocations::checked_update_session_quota();
 		System::reset_events();
-		on_finalize(10);
+		System::set_block_number(10);
+		Allocations::checked_update_session_quota();
 		let events: Vec<_> = System::events()
 			.into_iter()
 			.map(|event_record| event_record.event)
@@ -387,18 +403,25 @@ fn emit_session_quota_renewed_at_the_beginning_of_a_session() {
 #[test]
 fn emit_session_quota_calculated_at_the_beginning_of_a_fiscal_period() {
 	new_test_ext().execute_with(|| {
-		let total_issuance = 1000u64;
+		let total_issuance = 100000u64;
 		let _issuance = Balances::issue(total_issuance);
-		on_finalize(7);
+		let session_share = total_issuance * MINT_CURVE.session_period() / MINT_CURVE.fiscal_period();
+		System::set_block_number(7);
+		Allocations::checked_update_session_quota();
 		System::reset_events();
-		on_finalize(17);
+		System::set_block_number(16);
+		Allocations::checked_update_session_quota();
+		System::reset_events();
+		System::set_block_number(17);
+		let session_quota = THREE_INFLATION_STEPS[1] * session_share;
+		Allocations::checked_update_session_quota();
 		let events: Vec<_> = System::events()
 			.into_iter()
 			.map(|event_record| event_record.event)
 			.collect();
 		assert_eq!(
 			events,
-			vec![Event::Allocations(crate::Event::SessionQuotaCalculated(6))]
+			vec![Event::Allocations(crate::Event::SessionQuotaCalculated(session_quota))]
 		);
 	})
 }
@@ -406,28 +429,32 @@ fn emit_session_quota_calculated_at_the_beginning_of_a_fiscal_period() {
 #[test]
 fn next_session_quota() {
 	new_test_ext().execute_with(|| {
-		let total_issuance = 1000u64;
+		let total_issuance = 100000u64;
 		let _issuance = Balances::issue(total_issuance);
 		let session_share = total_issuance * MINT_CURVE.session_period() / MINT_CURVE.fiscal_period();
-		on_finalize(7);
+		System::set_block_number(7);
+		Allocations::checked_update_session_quota();
 		assert_eq!(
 			Allocations::next_session_quota(),
-			Some(THREE_INFLATION_STEPS[0] * session_share)
+			THREE_INFLATION_STEPS[0] * session_share
 		);
-		on_finalize(17);
+		System::set_block_number(17);
+		Allocations::checked_update_session_quota();
 		assert_eq!(
 			Allocations::next_session_quota(),
-			Some(THREE_INFLATION_STEPS[1] * session_share)
+			THREE_INFLATION_STEPS[1] * session_share
 		);
-		on_finalize(27);
+		System::set_block_number(27);
+		Allocations::checked_update_session_quota();
 		assert_eq!(
 			Allocations::next_session_quota(),
-			Some(THREE_INFLATION_STEPS[2] * session_share)
+			THREE_INFLATION_STEPS[2] * session_share
 		);
-		on_finalize(87);
+		System::set_block_number(87);
+		Allocations::checked_update_session_quota();
 		assert_eq!(
 			Allocations::next_session_quota(),
-			Some(THREE_INFLATION_STEPS[2] * session_share)
+			THREE_INFLATION_STEPS[2] * session_share
 		);
 	})
 }
@@ -439,11 +466,15 @@ fn next_session_quota_stays_the_same_during_one_fiscal_period() {
 		let _issuance = Balances::issue(total_issuance);
 		let quota =
 			THREE_INFLATION_STEPS[0] * total_issuance * MINT_CURVE.session_period() / MINT_CURVE.fiscal_period();
-		on_finalize(10);
-		on_finalize(11);
-		assert_eq!(Allocations::next_session_quota(), Some(quota));
-		on_finalize(19);
-		assert_eq!(Allocations::next_session_quota(), Some(quota));
+		System::set_block_number(10);
+		Allocations::checked_update_session_quota();
+		assert_eq!(Allocations::next_session_quota(), quota);
+		System::set_block_number(11);
+		Allocations::checked_update_session_quota();
+		assert_eq!(Allocations::next_session_quota(), quota);
+		System::set_block_number(19);
+		Allocations::checked_update_session_quota();
+		assert_eq!(Allocations::next_session_quota(), quota);
 	})
 }
 
@@ -451,19 +482,6 @@ fn next_session_quota_stays_the_same_during_one_fiscal_period() {
 fn session_quota_is_initially_zero() {
 	new_test_ext().execute_with(|| {
 		assert_eq!(Allocations::session_quota(), 0);
-	})
-}
-
-#[test]
-fn relative_block_number() {
-	new_test_ext().execute_with(|| {
-		on_finalize(13);
-
-		on_finalize(17);
-		assert_eq!(Allocations::relative_block_number(), 4);
-
-		on_finalize(11);
-		assert_eq!(Allocations::relative_block_number(), 0);
 	})
 }
 
@@ -476,27 +494,29 @@ fn session_quota_is_renewed_every_session() {
 
 		let quota0 = THREE_INFLATION_STEPS[0] * session_share;
 		let quota1 = THREE_INFLATION_STEPS[1] * session_share;
-		on_finalize(2);
+		System::set_block_number(2);
+		Allocations::checked_update_session_quota();
 
-		assert_eq!(Allocations::next_session_quota(), Some(quota0));
+		assert_eq!(Allocations::next_session_quota(), quota0);
 		assert_eq!(Allocations::session_quota(), quota0);
 
-		on_finalize(5);
+		System::set_block_number(5);
+		Allocations::checked_update_session_quota();
 		assert_eq!(Allocations::session_quota(), quota0);
 
 		// Consume session quota and check it will be renewed on a new session
 		<SessionQuota<Test>>::put(0);
 
-		on_finalize(7);
+		System::set_block_number(7);
+		Allocations::checked_update_session_quota();
 		assert_eq!(Allocations::session_quota(), 0);
 
-		on_finalize(8);
+		System::set_block_number(8);
+		Allocations::checked_update_session_quota();
 		assert_eq!(Allocations::session_quota(), quota0);
 
-		on_finalize(12);
-		assert_eq!(Allocations::session_quota(), quota0);
-
-		on_finalize(14);
+		System::set_block_number(12);
+		Allocations::checked_update_session_quota();
 		assert_eq!(Allocations::session_quota(), quota1);
 	})
 }
@@ -504,6 +524,8 @@ fn session_quota_is_renewed_every_session() {
 #[test]
 fn non_oracle_is_rejected() {
 	new_test_ext().execute_with(|| {
+		let total_issuance = 100000u64;
+		let _issuance = Balances::issue(total_issuance);
 		assert_noop!(
 			Allocations::batch(Origin::signed(Hacker::get()), bounded_vec![(Grantee::get(), 50)]),
 			Errors::OracleAccessDenied
@@ -514,7 +536,8 @@ fn non_oracle_is_rejected() {
 #[test]
 fn oracle_does_not_pay_fees() {
 	new_test_ext().execute_with(|| {
-		<SessionQuota<Test>>::put(50);
+		let total_issuance = 100000u64;
+		let _issuance = Balances::issue(total_issuance);
 		assert_eq!(
 			Allocations::batch(Origin::signed(Oracle::get()), bounded_vec![(Grantee::get(), 50)]),
 			Ok(Pays::No.into())
@@ -541,7 +564,8 @@ fn only_root_can_set_curve_starting_block() {
 #[test]
 fn simple_allocation_works() {
 	new_test_ext().execute_with(|| {
-		<SessionQuota<Test>>::put(50);
+		let total_issuance = 100000u64;
+		let _issuance = Balances::issue(total_issuance);
 		assert_ok!(Allocations::batch(
 			Origin::signed(Oracle::get()),
 			bounded_vec![(Grantee::get(), 50)]
@@ -557,12 +581,13 @@ fn simple_allocation_works() {
 #[test]
 fn batched_allocation_works() {
 	new_test_ext().execute_with(|| {
-		<SessionQuota<Test>>::put(120);
+		let total_issuance = 100000u64;
+		let _issuance = Balances::issue(total_issuance);
 		assert_ok!(Allocations::batch(
 			Origin::signed(Oracle::get()),
 			bounded_vec![(Grantee::get(), 50), (OtherGrantee::get(), 50)]
 		));
-		assert_eq!(Allocations::session_quota(), 20);
+		assert_eq!(Allocations::session_quota(), 200);
 		assert_eq!(Balances::free_balance(Grantee::get()), 45);
 		assert_eq!(Balances::free_balance(OtherGrantee::get()), 45);
 		assert_eq!(Balances::free_balance(Receiver::get()), 10);
@@ -575,7 +600,8 @@ fn batched_allocation_works() {
 #[test]
 fn use_session_quota_in_multiple_calls() {
 	new_test_ext().execute_with(|| {
-		<SessionQuota<Test>>::put(150);
+		let total_issuance = 50000u64;
+		let _issuance = Balances::issue(total_issuance);
 		assert_ok!(Allocations::batch(
 			Origin::signed(Oracle::get()),
 			bounded_vec![(Grantee::get(), 30), (OtherGrantee::get(), 50)]

--- a/pallets/allocations/src/weights.rs
+++ b/pallets/allocations/src/weights.rs
@@ -48,8 +48,7 @@ use sp_std::marker::PhantomData;
 
 /// Weight functions needed for pallet_allocations.
 pub trait WeightInfo {
-	fn allocate() -> Weight;
-	fn batch(b: u32) -> Weight;
+	fn allocate(b: u32) -> Weight;
 	fn set_curve_starting_block() -> Weight;
 	fn calc_quota() -> Weight;
 	fn renew_quota() -> Weight;
@@ -58,19 +57,25 @@ pub trait WeightInfo {
 /// Weights for pallet_allocations using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	fn allocate() -> Weight {
-		(63_000_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(10 as Weight))
-			.saturating_add(T::DbWeight::get().writes(7 as Weight))
-	}
-	fn batch(b: u32) -> Weight {
-		(31_074_000 as Weight) // Standard Error: 8_000
-			.saturating_add((18_533_000 as Weight).saturating_mul(b as Weight))
-			.saturating_add(T::DbWeight::get().reads(9 as Weight))
+	// Storage: Allocations SessionQuota (r:1 w:1)
+	// Storage: Balances TotalIssuance (r:1 w:1)
+	// Storage: System Account (r:3 w:3)
+	// Storage: System Number (r:1 w:0)
+	// Storage: System ExecutionPhase (r:1 w:0)
+	// Storage: System EventCount (r:1 w:1)
+	// Storage: System Events (r:1 w:1)
+	/// The range of component `b` is `[1, 500]`.
+	fn allocate(b: u32) -> Weight {
+		(0 as Weight)
+			// Standard Error: 4_000
+			.saturating_add((7_946_000 as Weight).saturating_mul(b as Weight))
+			.saturating_add(T::DbWeight::get().reads(8 as Weight))
 			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(b as Weight)))
 			.saturating_add(T::DbWeight::get().writes(6 as Weight))
 			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(b as Weight)))
 	}
+	// Storage: Allocations SessionQuotaCalculationSchedule (r:1 w:1)
+	// Storage: Allocations MintCurveStartingBlock (r:1 w:1)
 	// Storage: Balances TotalIssuance (r:1 w:0)
 	// Storage: System Number (r:1 w:0)
 	// Storage: System ExecutionPhase (r:1 w:0)
@@ -78,10 +83,12 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: System Events (r:1 w:1)
 	// Storage: Allocations NextSessionQuota (r:0 w:1)
 	fn calc_quota() -> Weight {
-		(7_000_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		(9_000_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(7 as Weight))
+			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
+	// Storage: Allocations SessionQuotaRenewSchedule (r:1 w:1)
+	// Storage: Allocations MintCurveStartingBlock (r:1 w:1)
 	// Storage: Allocations NextSessionQuota (r:1 w:0)
 	// Storage: System Number (r:1 w:0)
 	// Storage: System ExecutionPhase (r:1 w:0)
@@ -89,42 +96,44 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: System Events (r:1 w:1)
 	// Storage: Allocations SessionQuota (r:0 w:1)
 	fn renew_quota() -> Weight {
-		(6_000_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+		(9_000_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(7 as Weight))
+			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
+	// Storage: ParachainSystem ValidationData (r:1 w:0)
 	// Storage: Allocations MintCurveStartingBlock (r:0 w:1)
+	// Storage: Allocations SessionQuotaCalculationSchedule (r:0 w:1)
+	// Storage: Allocations SessionQuotaRenewSchedule (r:0 w:1)
 	fn set_curve_starting_block() -> Weight {
-		(2_000_000 as Weight).saturating_add(T::DbWeight::get().writes(1 as Weight))
+		(4_000_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 }
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
-	fn allocate() -> Weight {
-		(63_000_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(10 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
-	}
-	fn batch(b: u32) -> Weight {
-		(31_074_000 as Weight) // Standard Error: 8_000
-			.saturating_add((18_533_000 as Weight).saturating_mul(b as Weight))
-			.saturating_add(RocksDbWeight::get().reads(9 as Weight))
+	fn allocate(b: u32) -> Weight {
+		(0 as Weight)
+			.saturating_add((7_946_000 as Weight).saturating_mul(b as Weight))
+			.saturating_add(RocksDbWeight::get().reads(8 as Weight))
 			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(b as Weight)))
 			.saturating_add(RocksDbWeight::get().writes(6 as Weight))
 			.saturating_add(RocksDbWeight::get().writes((1 as Weight).saturating_mul(b as Weight)))
 	}
 	fn calc_quota() -> Weight {
-		(7_000_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(5 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
+		(9_000_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
 	}
 	fn renew_quota() -> Weight {
-		(6_000_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(5 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
+		(9_000_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
 	}
 	fn set_curve_starting_block() -> Weight {
-		(2_000_000 as Weight).saturating_add(RocksDbWeight::get().writes(1 as Weight))
+		(4_000_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
 	}
 }

--- a/pallets/allocations/src/weights.rs
+++ b/pallets/allocations/src/weights.rs
@@ -52,6 +52,7 @@ pub trait WeightInfo {
 	fn set_curve_starting_block() -> Weight;
 	fn calc_quota() -> Weight;
 	fn renew_quota() -> Weight;
+	fn checked_update_session_quota() -> Weight;
 }
 
 /// Weights for pallet_allocations using the Substrate node and recommended hardware.
@@ -101,6 +102,22 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
 	// Storage: ParachainSystem ValidationData (r:1 w:0)
+	// Storage: Allocations SessionQuotaCalculationSchedule (r:1 w:1)
+	// Storage: Allocations MintCurveStartingBlock (r:1 w:1)
+	// Storage: Balances TotalIssuance (r:1 w:0)
+	// Storage: System Number (r:1 w:0)
+	// Storage: System ExecutionPhase (r:1 w:0)
+	// Storage: System EventCount (r:1 w:1)
+	// Storage: System Events (r:1 w:1)
+	// Storage: Allocations SessionQuotaRenewSchedule (r:1 w:1)
+	// Storage: Allocations SessionQuota (r:0 w:1)
+	// Storage: Allocations NextSessionQuota (r:0 w:1)
+	fn checked_update_session_quota() -> Weight {
+		(13_000_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(9 as Weight))
+			.saturating_add(T::DbWeight::get().writes(7 as Weight))
+	}
+	// Storage: ParachainSystem ValidationData (r:1 w:0)
 	// Storage: Allocations MintCurveStartingBlock (r:0 w:1)
 	// Storage: Allocations SessionQuotaCalculationSchedule (r:0 w:1)
 	// Storage: Allocations SessionQuotaRenewSchedule (r:0 w:1)
@@ -130,6 +147,11 @@ impl WeightInfo for () {
 		(9_000_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
+	}
+	fn checked_update_session_quota() -> Weight {
+		(13_000_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(9 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
 	}
 	fn set_curve_starting_block() -> Weight {
 		(4_000_000 as Weight)


### PR DESCRIPTION
Move quota calculations to happen in the first successful `batch` call in a fiscal period. Same for quota renewal that would happen in the first successful call in a session period. 
This new approach relies on adding two new storage for storing the schedules for quota calculations and renewals. The additional cost to most of the batch calls would be only three additional storage reads. However in those batch calls where the calculation and or renewal of quota is needed the cost would be more. 
The benefit of this new approach is that it doesn't rely on any block initialisation or finalisation process. And if there is no batch call in a block, there is now overhead related to the allocations for the block. The implementation is also capable of being based on both relay chain block numbers or parachain block numbers and doesn't need to happen in all the blocks.
The disadvantage is first a batch call occasionally does stuff not directly related to allocating rewards to the given list. Also when a batch call fails even though the call is not decorated with `#[transactional]` macro, all the storage changes including the calculation or renewal of the quota is reverted which leads to the same calculations and updates to be needed for the next call.