### PR TITLE
chore: prepare for releasing 2.0.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "nodle-parachain"
-version = "2.0.23"
+version = "2.0.24"
 dependencies = [
  "clap",
  "cumulus-client-cli",
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-allocations"
-version = "2.0.23"
+version = "2.0.24"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-grants"
-version = "2.0.23"
+version = "2.0.24"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5290,7 +5290,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-mandate"
-version = "2.0.23"
+version = "2.0.24"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5456,7 +5456,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-poa"
-version = "2.0.23"
+version = "2.0.24"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-reserve"
-version = "2.0.23"
+version = "2.0.24"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "2.0.23"
+version = "2.0.24"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7360,7 +7360,7 @@ dependencies = [
 
 [[package]]
 name = "primitives"
-version = "2.0.23"
+version = "2.0.24"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7995,7 +7995,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-eden"
-version = "2.0.23"
+version = "2.0.24"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -10586,7 +10586,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "support"
-version = "2.0.23"
+version = "2.0.24"
 
 [[package]]
 name = "syn"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Nodle <support@nodle.com>", "Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"
 name = "nodle-parachain"
-version = "2.0.23"
+version = "2.0.24"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/allocations/Cargo.toml
+++ b/pallets/allocations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-allocations"
-version = "2.0.23"
+version = "2.0.24"
 authors = ['Eliott Teissonniere <git.eliott@teissonniere.org>']
 edition = "2021"
 description = "A pallet to handle the Proof Of Connectivity allocations rewards"

--- a/pallets/grants/Cargo.toml
+++ b/pallets/grants/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pallet-grants"
 description = "Provides scheduled balance locking mechanism, in a *graded vesting* way."
 license = "Apache-2.0"
-version = "2.0.23"
+version = "2.0.24"
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 

--- a/pallets/mandate/Cargo.toml
+++ b/pallets/mandate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-mandate"
-version = "2.0.23"
+version = "2.0.24"
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 

--- a/pallets/poa/Cargo.toml
+++ b/pallets/poa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-poa"
-version = "2.0.23"
+version = "2.0.24"
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 

--- a/pallets/reserve/Cargo.toml
+++ b/pallets/reserve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-reserve"
-version = "2.0.23"
+version = "2.0.24"
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 

--- a/pallets/staking/Cargo.toml
+++ b/pallets/staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-staking"
-version = "2.0.23"
+version = "2.0.24"
 authors = [
 	'Eliott Teissonniere <git.eliott@teissonniere.org>, R.RajeshKumar <rajesh@nodle.co>',
 ]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitives"
-version = "2.0.23"
+version = "2.0.24"
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 

--- a/runtimes/eden/Cargo.toml
+++ b/runtimes/eden/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 name = "runtime-eden"
-version = "2.0.23"
+version = "2.0.24"
 
 [features]
 default = ["std"]

--- a/runtimes/eden/src/version.rs
+++ b/runtimes/eden/src/version.rs
@@ -50,7 +50,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_version: 0,
 
 	/// Used for hardware wallets. This typically happens when `SignedExtra` changes.
-	transaction_version: 4,
+	transaction_version: 5,
 
 	apis: RUNTIME_API_VERSIONS,
 	state_version: 0,

--- a/support/Cargo.toml
+++ b/support/Cargo.toml
@@ -2,4 +2,4 @@
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 name = "support"
-version = "2.0.23"
+version = "2.0.24"


### PR DESCRIPTION
A change in the uniques pallet coming through using polkadot 0.9.28, would require us to bump the tx version and rebuild the nodle app on Ledger.