### PR TITLE
fix(runtime-eden): recognise xtokens' nodlNative as known asset

### DIFF
--- a/runtimes/eden/src/weights/mod.rs
+++ b/runtimes/eden/src/weights/mod.rs
@@ -25,6 +25,7 @@ use pallet_xcm_benchmarks_fungible::WeightInfo as XcmBalancesWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
 
 /// Types of asset supported by the Nodle runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AssetTypes {
 	/// An asset backed by `pallet-balances`.
 	Balances,
@@ -40,14 +41,14 @@ impl From<&MultiAsset> for AssetTypes {
 					parents: 0,
 					interior: Here,
 				}),
-				..
+				fun: Fungible(_),
 			} => AssetTypes::Balances,
 			MultiAsset {
 				id: Concrete(MultiLocation {
 					parents: 0,
 					interior: X1(PalletInstance(2)),
 				}),
-				..
+				fun: Fungible(_),
 			} => AssetTypes::Balances,
 			_ => AssetTypes::Unknown,
 		}
@@ -203,5 +204,87 @@ impl<RuntimeCall> XcmWeightInfo<RuntimeCall> for NodleXcmWeight<RuntimeCall> {
 	}
 	fn unsubscribe_version() -> XCMWeight {
 		XcmGeneric::<Runtime>::unsubscribe_version().ref_time()
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn test_multi_asset_conversion_to_asset_types() {
+		let asset = MultiAsset {
+			id: Concrete(MultiLocation {
+				parents: 0,
+				interior: X1(PalletInstance(2)),
+			}),
+			fun: Fungible(100),
+		};
+		let asset_type = AssetTypes::from(&asset);
+		assert_eq!(asset_type, AssetTypes::Balances);
+
+		let asset = MultiAsset {
+			id: Concrete(MultiLocation {
+				parents: 0,
+				interior: Here,
+			}),
+			fun: Fungible(43),
+		};
+		let asset_type = AssetTypes::from(&asset);
+		assert_eq!(asset_type, AssetTypes::Balances);
+
+		let asset = MultiAsset {
+			id: Concrete(MultiLocation {
+				parents: 0,
+				interior: X1(PalletInstance(3)),
+			}),
+			fun: Fungible(100),
+		};
+		let asset_type = AssetTypes::from(&asset);
+		assert_eq!(asset_type, AssetTypes::Unknown);
+
+		let asset = MultiAsset {
+			id: Concrete(MultiLocation {
+				parents: 1,
+				interior: Here,
+			}),
+			fun: Fungible(43),
+		};
+		let asset_type = AssetTypes::from(&asset);
+		assert_eq!(asset_type, AssetTypes::Unknown);
+
+		let asset = MultiAsset {
+			id: Abstract(vec![]),
+			fun: Fungible(100),
+		};
+		let asset_type = AssetTypes::from(&asset);
+		assert_eq!(asset_type, AssetTypes::Unknown);
+
+		let asset = MultiAsset {
+			id: Abstract(vec![]),
+			fun: NonFungible(AssetInstance::Index(0)),
+		};
+		let asset_type = AssetTypes::from(&asset);
+		assert_eq!(asset_type, AssetTypes::Unknown);
+
+		let asset = MultiAsset {
+			id: Concrete(MultiLocation {
+				parents: 0,
+				interior: Here,
+			}),
+			fun: NonFungible(AssetInstance::Index(2)),
+		};
+		let asset_type = AssetTypes::from(&asset);
+		assert_eq!(asset_type, AssetTypes::Unknown);
+
+		let asset = MultiAsset {
+			id: Concrete(MultiLocation {
+				parents: 0,
+				interior: X1(PalletInstance(2)),
+			}),
+			fun: NonFungible(AssetInstance::Index(0)),
+		};
+		let asset_type = AssetTypes::from(&asset);
+		assert_eq!(asset_type, AssetTypes::Unknown);
 	}
 }

--- a/runtimes/eden/src/weights/mod.rs
+++ b/runtimes/eden/src/weights/mod.rs
@@ -42,6 +42,13 @@ impl From<&MultiAsset> for AssetTypes {
 				}),
 				..
 			} => AssetTypes::Balances,
+			MultiAsset {
+				id: Concrete(MultiLocation {
+					parents: 0,
+					interior: X1(PalletInstance(2)),
+				}),
+				..
+			} => AssetTypes::Balances,
 			_ => AssetTypes::Unknown,
 		}
 	}

--- a/runtimes/eden/src/xcm_config.rs
+++ b/runtimes/eden/src/xcm_config.rs
@@ -21,9 +21,9 @@ use sp_runtime::traits::Convert;
 use xcm::{latest::NetworkId, latest::Weight as XcmWeight, prelude::*};
 use xcm_builder::{
 	AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom, AllowTopLevelPaidExecutionFrom,
-	CurrencyAdapter, EnsureXcmOrigin, FixedWeightBounds, IsConcrete, LocationInverter, NativeAsset, ParentIsPreset,
-	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
-	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, UsingComponents, WeightInfoBounds,
+	CurrencyAdapter, EnsureXcmOrigin, IsConcrete, LocationInverter, NativeAsset, ParentIsPreset, RelayChainAsNative,
+	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
+	SovereignSignedViaLocation, TakeWeightCredit, UsingComponents, WeightInfoBounds,
 };
 use xcm_executor::XcmExecutor;
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
@@ -206,7 +206,7 @@ impl orml_xtokens::Config for Runtime {
 	type AccountIdToMultiLocation = AccountIdToMultiLocation;
 	type SelfLocation = SelfLocation;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
-	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
+	type Weigher = WeightInfoBounds<crate::weights::NodleXcmWeight<RuntimeCall>, RuntimeCall, MaxInstructions>;
 	type BaseXcmWeight = BaseXcmWeight;
 	type LocationInverter = LocationInverter<Ancestry>;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;


### PR DESCRIPTION
We refer to NODL as an asset represented by our pallet instance 2 (pallet-balances) on our parachain and this location should be regarded as a known asset type.
Also fix xTokens to use the same weigher as xcm -executor.