### PR TITLE
chore: prepare to release 2.0.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5002,7 +5002,7 @@ dependencies = [
 
 [[package]]
 name = "nodle-parachain"
-version = "2.0.28"
+version = "2.0.30"
 dependencies = [
  "clap",
  "cumulus-client-cli",
@@ -5374,7 +5374,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-allocations"
-version = "2.0.28"
+version = "2.0.30"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-grants"
-version = "2.0.28"
+version = "2.0.30"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5868,7 +5868,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-mandate"
-version = "2.0.28"
+version = "2.0.30"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6134,7 +6134,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-reserve"
-version = "2.0.28"
+version = "2.0.30"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8028,7 +8028,7 @@ dependencies = [
 
 [[package]]
 name = "primitives"
-version = "2.0.28"
+version = "2.0.30"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8719,7 +8719,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-eden"
-version = "2.0.28"
+version = "2.0.30"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -11442,7 +11442,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "support"
-version = "2.0.28"
+version = "2.0.30"
 
 [[package]]
 name = "syn"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Nodle <support@nodle.com>", "Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"
 name = "nodle-parachain"
-version = "2.0.28"
+version = "2.0.30"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/allocations/Cargo.toml
+++ b/pallets/allocations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-allocations"
-version = "2.0.28"
+version = "2.0.30"
 authors = ['Eliott Teissonniere <git.eliott@teissonniere.org>']
 edition = "2021"
 description = "A pallet to handle the Proof Of Connectivity allocations rewards"

--- a/pallets/grants/Cargo.toml
+++ b/pallets/grants/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pallet-grants"
 description = "Provides scheduled balance locking mechanism, in a *graded vesting* way."
 license = "Apache-2.0"
-version = "2.0.28"
+version = "2.0.30"
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 

--- a/pallets/mandate/Cargo.toml
+++ b/pallets/mandate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-mandate"
-version = "2.0.28"
+version = "2.0.30"
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 

--- a/pallets/reserve/Cargo.toml
+++ b/pallets/reserve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-reserve"
-version = "2.0.28"
+version = "2.0.30"
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primitives"
-version = "2.0.28"
+version = "2.0.30"
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 

--- a/runtimes/eden/Cargo.toml
+++ b/runtimes/eden/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 name = "runtime-eden"
-version = "2.0.28"
+version = "2.0.30"
 
 [features]
 default = ["std"]

--- a/runtimes/eden/src/version.rs
+++ b/runtimes/eden/src/version.rs
@@ -39,7 +39,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	/// Version of the runtime specification. A full-node will not attempt to use its native
 	/// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
 	/// `spec_version` and `authoring_version` are the same between Wasm and native.
-	spec_version: 19,
+	spec_version: 20,
 
 	/// Version of the implementation of the specification. Nodes are free to ignore this; it
 	/// serves only as an indication that the code is different; as long as the other two versions

--- a/support/Cargo.toml
+++ b/support/Cargo.toml
@@ -2,4 +2,4 @@
 authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
 edition = "2021"
 name = "support"
-version = "2.0.28"
+version = "2.0.30"


### PR DESCRIPTION
We need to have a minor release which contains the fix for our xtoken weigher.