### PR TITLE
Optimize github actions to be cheaper and cleaner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest-8-cores
+    needs: lints
 
     steps:
       - uses: actions/checkout@v3
@@ -77,6 +78,8 @@ jobs:
 
   linecoverage:
     runs-on: ubuntu-latest-4-cores
+    needs: tests
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -99,6 +102,8 @@ jobs:
   try-runtime:
     runs-on: ubuntu-latest-8-cores
     timeout-minutes: 50
+    needs: tests
+
     steps:
       - uses: actions/checkout@v3
       - name: Check Version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest-8-cores
-    needs: lints
 
     steps:
       - uses: actions/checkout@v3
@@ -78,7 +77,6 @@ jobs:
 
   linecoverage:
     runs-on: ubuntu-latest-4-cores
-    needs: tests
 
     steps:
       - uses: actions/checkout@v3
@@ -102,7 +100,6 @@ jobs:
   try-runtime:
     runs-on: ubuntu-latest-8-cores
     timeout-minutes: 50
-    needs: tests
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   lints:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   lints:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   autodoc:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,10 +1,6 @@
 name: Docker
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
   release:
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ jobs:
 
   container_gpr:
     name: Build and push docker image
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
 
     steps:
 

--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-    pull_request:
 
 jobs:
   srtool:


### PR DESCRIPTION
Reduce the runner size for non priority workflows and optimize frequency of runs (for instance we really only need a docker container to be built once a release is issued).

Beyond being less noisy and failing faster when necessary, this might save us a little money.