### PR TITLE
fix and improve devcontainer prebuild

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,10 @@
+# This Dockerfile is used to build the Dev Container for VSCode
+# and GitHub Codespaces.
+# It is based on the official VSCode Dev Container for Rust and
+# pre-installs the required dependencies for the Nodle Chain
+# development along with SubWasm and a prebuilt Polkadot
+# binary.
+
 FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu
 
 USER root

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,9 @@
     // This run during prebuild and allows the user to start with a container
     // containing the latest compiled dependencies and save on the first compilation
     // cycle which is usually absurdly slow.
-    "updateContentCommand": "cargo build",
+    // We exclude nodle-parachain because it oftens pose problems in the constricted
+    // environment of the github prebuild system.
+    "updateContentCommand": "cargo build --all --exclude nodle-parachain",
     // Ensure every codespace have the minimum resources to comfortably support the
     // project.
     "hostRequirements": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,9 @@
 {
     "build": {
         "dockerfile": "Dockerfile",
-        "context": ".."
+        "context": "..",
+        // Prebuilt in CI/CD
+        "cacheFrom": "ghcr.io/nodlecode/devcontainer-chain"
     },
     "features": {
         "github-cli": "latest",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
     // This run during prebuild and allows the user to start with a container
     // containing the latest compiled dependencies and save on the first compilation
     // cycle which is usually absurdly slow.
-    "updateContentCommand": "cargo test --all --no-run",
+    "updateContentCommand": "cargo build",
     // Ensure every codespace have the minimum resources to comfortably support the
     // project.
     "hostRequirements": {

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,0 +1,32 @@
+name: DevContainer
+
+on:
+  push:
+    # branches:
+    #   - master
+
+
+jobs:
+
+  build:
+    name: Build and cache devcontainer image
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pre-build dev container image
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ghcr.io/nodlecode/devcontainer-chain
+          cacheFrom: ghcr.io/nodlecode/devcontainer-chain
+          push: always

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,10 +1,8 @@
 name: DevContainer
 
 on:
-  push:
-    # branches:
-    #   - master
-
+  schedule:
+    - cron:  '0 0 * * 0'
 
 jobs:
 


### PR DESCRIPTION
- only run build, not tests
- create our own cached image in CI
- doc devcontainer
- use prebuilt devcontainer
- exclude nodle-parachain
- schedule devcontainer build for once a week
