### PR TITLE
feat: add nodle uniques which is going to extend on substrate uniques

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6005,6 +6005,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-nodle-uniques"
+version = "2.1.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.40#76fed9b9082daade5392663f25ed8968f8e8c11c"
@@ -8813,6 +8828,7 @@ dependencies = [
  "pallet-mandate",
  "pallet-membership",
  "pallet-multisig",
+ "pallet-nodle-uniques",
  "pallet-offences",
  "pallet-preimage",
  "pallet-reserve",

--- a/pallets/uniques/Cargo.toml
+++ b/pallets/uniques/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "pallet-nodle-uniques"
+version = "2.1.0"
+authors = ["Eliott Teissonniere <git.eliott@teissonniere.org>"]
+edition = "2021"
+
+[features]
+default = ["std"]
+std = [
+  "codec/std",
+  "serde",
+  "scale-info/std",
+  "frame-support/std",
+  "frame-system/std",
+  "sp-io/std",
+  "sp-runtime/std",
+  "sp-std/std",
+]
+try-runtime = ["frame-support/try-runtime"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.152", optional = true, features = ["derive"] }
+scale-info = { version = "2.0.1", default-features = false, features = [
+  "derive",
+] }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.40" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }

--- a/pallets/uniques/src/lib.rs
+++ b/pallets/uniques/src/lib.rs
@@ -1,0 +1,99 @@
+/*
+ * This file is part of the Nodle Chain distributed at https://github.com/NodleCode/chain
+ * Copyright (C) 2020-2022  Nodle International
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//! Handle the ability to notify other pallets that they should stop all
+//! operations, or resume them
+
+use frame_support::traits::nonfungibles::Inspect;
+pub use pallet::*;
+use sp_runtime::traits::StaticLookup;
+
+type AccountIdLookupOf<T> = <<T as frame_system::Config>::Lookup as StaticLookup>::Source;
+type CollectionIdOf<T> =
+	<<T as pallet::Config>::NonFungible as Inspect<<T as frame_system::Config>::AccountId>>::CollectionId;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use frame_support::{
+		pallet_prelude::*,
+		traits::{
+			tokens::nonfungibles::{Create, Destroy, InspectEnumerable, Mutate, Transfer},
+			EnsureOriginWithArg,
+		},
+		Parameter,
+	};
+	use frame_system::pallet_prelude::*;
+	use sp_runtime::DispatchResult;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// Standard collection creation is only allowed if the origin attempting it and the
+		/// collection are in this set.
+		type CreateOrigin: EnsureOriginWithArg<Self::RuntimeOrigin, CollectionIdOf<Self>, Success = Self::AccountId>;
+
+		type NonFungible: Mutate<Self::AccountId>
+			+ Transfer<Self::AccountId>
+			+ Create<Self::AccountId>
+			+ Destroy<Self::AccountId>
+			+ InspectEnumerable<Self::AccountId>;
+	}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(PhantomData<T>);
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T>
+	where
+		CollectionIdOf<T>: Member + Parameter + MaxEncodedLen + Copy,
+	{
+		/// Issue a new collection of non-fungible items from a public origin.
+		///
+		/// This new collection has no items initially and its owner is the origin.
+		///
+		/// The origin must conform to the configured `CreateOrigin` and have sufficient funds free.
+		///
+		/// `ItemDeposit` funds of sender are reserved.
+		///
+		/// Parameters:
+		/// - `collection`: The identifier of the new collection. This must not be currently in use.
+		/// - `admin`: The admin of this collection. The admin is the initial address of each
+		/// member of the collection's admin team.
+		///
+		/// Emits `Created` event when successful.
+		///
+		/// Weight: `O(1)`
+		#[pallet::call_index(0)]
+		#[pallet::weight(0)]
+		pub fn create(
+			origin: OriginFor<T>,
+			collection: CollectionIdOf<T>,
+			admin: AccountIdLookupOf<T>,
+		) -> DispatchResult {
+			let owner = T::CreateOrigin::ensure_origin(origin, &collection)?;
+			let admin = T::Lookup::lookup(admin)?;
+
+			<T::NonFungible as Create<T::AccountId>>::create_collection(&collection, &owner, &admin)
+		}
+	}
+}

--- a/runtimes/eden/Cargo.toml
+++ b/runtimes/eden/Cargo.toml
@@ -24,6 +24,7 @@ std = [
   "pallet-mandate/std",
   "pallet-membership/std",
   "pallet-multisig/std",
+  "pallet-nodle-uniques/std",
   "pallet-offences/std",
   "pallet-insecure-randomness-collective-flip/std",
   "pallet-reserve/std",
@@ -118,6 +119,7 @@ try-runtime = [
   "pallet-mandate/try-runtime",
   "pallet-membership/try-runtime",
   "pallet-multisig/try-runtime",
+  "pallet-nodle-uniques/try-runtime",
   "pallet-offences/try-runtime",
   "pallet-insecure-randomness-collective-flip/try-runtime",
   "pallet-reserve/try-runtime",
@@ -222,6 +224,7 @@ pallet-allocations = { default-features = false, path = "../../pallets/allocatio
 pallet-reserve = { default-features = false, path = "../../pallets/reserve" }
 pallet-grants = { default-features = false, path = "../../pallets/grants" }
 pallet-mandate = { default-features = false, path = "../../pallets/mandate" }
+pallet-nodle-uniques = { default-features = false, path = "../../pallets/uniques" }
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.40", default-features = false }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.40", default-features = false }
 [build-dependencies]

--- a/runtimes/eden/src/lib.rs
+++ b/runtimes/eden/src/lib.rs
@@ -110,8 +110,9 @@ construct_runtime! {
 		// Neat things
 		Utility: pallet_utility = 40,
 		Multisig: pallet_multisig = 41,
-		Uniques: pallet_uniques = 42,
+		SubstrateUniques: pallet_uniques::{Pallet, Storage, Event<T>} = 42,
 		Preimage: pallet_preimage::{Pallet, Call, Storage, Event<T>} = 43,
+		Uniques: pallet_nodle_uniques = 44,
 
 		// Nodle Stack
 		// EmergencyShutdown: pallet_emergency_shutdown = 50,
@@ -359,7 +360,7 @@ sp_api::impl_runtime_apis! {
 			list_benchmark!(list, extra, pallet_multisig, Multisig);
 			list_benchmark!(list, extra, pallet_reserve, CompanyReserve);
 			list_benchmark!(list, extra, pallet_grants, Vesting);
-			list_benchmark!(list, extra, pallet_uniques, Uniques);
+			list_benchmark!(list, extra, pallet_uniques, SubstrateUniques);
 			list_benchmark!(list, extra, pallet_utility, Utility);
 			list_benchmark!(list, extra, pallet_allocations, Allocations);
 			list_benchmark!(list, extra, pallet_collator_selection, CollatorSelection);
@@ -400,7 +401,7 @@ sp_api::impl_runtime_apis! {
 			add_benchmark!(params, batches, pallet_multisig, Multisig);
 			add_benchmark!(params, batches, pallet_reserve, CompanyReserve);
 			add_benchmark!(params, batches, pallet_grants, Vesting);
-			add_benchmark!(params, batches, pallet_uniques, Uniques);
+			add_benchmark!(params, batches, pallet_uniques, SubstrateUniques);
 			add_benchmark!(params, batches, pallet_utility, Utility);
 			add_benchmark!(params, batches, pallet_allocations, Allocations);
 			add_benchmark!(params, batches, pallet_collator_selection, CollatorSelection);

--- a/runtimes/eden/src/pallets_util.rs
+++ b/runtimes/eden/src/pallets_util.rs
@@ -19,7 +19,8 @@
 
 use crate::{
 	constants, implementations::RelayChainBlockNumberProvider, pallets_governance::MoreThanHalfOfTechComm, Balances,
-	OriginCaller, Preimage, RandomnessCollectiveFlip, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, Timestamp,
+	OriginCaller, Preimage, RandomnessCollectiveFlip, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin,
+	SubstrateUniques, Timestamp,
 };
 use frame_support::{
 	parameter_types,
@@ -135,6 +136,11 @@ impl pallet_uniques::Config for Runtime {
 	type Helper = ();
 	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
 	type Locker = ();
+}
+
+impl pallet_nodle_uniques::Config for Runtime {
+	type CreateOrigin = <Self as pallet_uniques::Config>::CreateOrigin;
+	type NonFungible = SubstrateUniques;
 }
 
 parameter_types! {


### PR DESCRIPTION
We want to allow an adjustable intrinsic value for NFTs on top of [what is fixed as the base intrinsic value](https://github.com/NodleCode/chain/pull/740/files#diff-bc781f5a3dd945b1c46c426a837c2bd87d1f19a31ba63080b52f1d615575951dL110-L113) in the runtime configuration. 
In order to make sure, all the substrate uniques calls go through this new pallet, we are going to remove the direct Call access to the substrate uniques pallet. We then aim to cover all the main substrate uniques calls wrapped in our own Nodle uniques calls. This is so we make sure no intrinsic values go lost and the proper accounting will happen on all related functions such as mint, destroy or transfer. The intrinsic value could then be reserved in an owner's account and repatriated on transfers and unreserved on destroy (similar to what is done for the fixed deposit for an NFT where it reserves the deposit ([1](https://github.com/paritytech/substrate/blob/polkadot-v0.9.40/frame/uniques/src/functions.rs#L79), [2](https://github.com/paritytech/substrate/blob/polkadot-v0.9.40/frame/uniques/src/functions.rs#L172)), [unreserve it](https://github.com/paritytech/substrate/blob/polkadot-v0.9.40/frame/uniques/src/functions.rs#L131) and [repatriate it](https://github.com/paritytech/substrate/blob/polkadot-v0.9.40/frame/uniques/src/lib.rs#L872C17-L878) on different calls).

- [ ] Similar to how it's done for the [Create extrinsic](https://github.com/NodleCode/chain/pull/740/files#diff-1576dccf99d110eae22e43b44c85d93777af4108c57eb7053020525880da3aadR88-R96), wrap and present the following calls in pallet_nodle_uniques:
- - [ ] `destroy`
- - [ ] `mint`
- - [ ] `burn`
- - [ ]  `transfer`

- [ ] Add `create_with_extra_deposit` and `mint_with_extra_deposit` extrinsics
- [ ] Add tests for the accounting of the extra deposit on all possible extrinsics
- [ ] Add benchmarks for pallet_nodle_uniques (you can get inspiration or use the same benchmarks tests as those for pallet_uniques
- [ ] Add migration to make sure the storage of the pallet_uniques which was called Uniques is now prefixed with SubstrateUniques instead and available through this new name.


**NOTE**: This is an initial draft showcasing the overall approach.