### PR TITLE
Use `runtime_version` attribute macro

### DIFF
--- a/runtimes/eden/src/version.rs
+++ b/runtimes/eden/src/version.rs
@@ -28,6 +28,7 @@ use sp_version::RuntimeVersion;
 /// In particular: bug fixes should result in an increment of `spec_version` and possibly
 /// `authoring_version`, absolutely not `impl_version` since they change the semantics of the
 /// runtime.
+#[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("nodle-para"),
 	impl_name: create_runtime_str!("nodle-para"),


### PR DESCRIPTION
This macro puts the `RuntimeVersion` into a custom section in the wasm file. This speedups reading the `RuntimeVersion`.