### PR TITLE
Update p2p addresses in eden-testing.json

### DIFF
--- a/node/res/eden-testing.json
+++ b/node/res/eden-testing.json
@@ -3,10 +3,10 @@
   "id": "para_eden_testing_0510",
   "chainType": "Live",
   "bootNodes": [
-    "/dns4/node-6909510104162127872-0.p2p.onfinality.io/tcp/19254/p2p/12D3KooWNhD2ssau5szUX8xc4jXheNH6GjmJMqRFyd7gcjy9SYGW",
-    "/dns4/node-6909510917362176000-0.p2p.onfinality.io/tcp/21182/p2p/12D3KooWA7A8ZRv6cDAKrnFRxqFLgStZDiRDo7sAiuHMud7r1yzo",
-    "/dns4/node-6909511454498566144-0.p2p.onfinality.io/tcp/13671/p2p/12D3KooWAbiceJbKkaA43HwKjVP2pkSLdeRDEEfByztwXtoXkBaG",
-    "/dns4/node-6909512134724104192-0.p2p.onfinality.io/tcp/17926/p2p/12D3KooWDuuh91zg7uUzFLrMwE7GEimAvzuXmsmsccjhhps98dzt"
+    "/dns4/node-6909510104162127872-0.p2p.onfinality.io/tcp/19254/ws/p2p/12D3KooWNhD2ssau5szUX8xc4jXheNH6GjmJMqRFyd7gcjy9SYGW",
+    "/dns4/node-6909510917362176000-0.p2p.onfinality.io/tcp/21182/ws/p2p/12D3KooWA7A8ZRv6cDAKrnFRxqFLgStZDiRDo7sAiuHMud7r1yzo",
+    "/dns4/node-7060042496888631296-0.p2p.onfinality.io/tcp/24918/ws/p2p/12D3KooWSPdkbHdimovqU6NkcnTAPjHH6EChggQouw1vZzRmbkSB",
+    "/dns4/node-6909512134724104192-0.p2p.onfinality.io/tcp/17926/ws/p2p/12D3KooWDuuh91zg7uUzFLrMwE7GEimAvzuXmsmsccjhhps98dzt"
   ],
   "telemetryEndpoints": [
     [


### PR DESCRIPTION
A previous collator is now terminated and a full node is added to serve the light client connections. Also there is a "ws" part added to the structure of the previous addresses recently.