### PR TITLE
deprecate try-runtime feature in favor of new CLI from Parity

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,4 +29,6 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     export PATH=$PATH:$HOME/.cargo/bin && \
     /tmp/init.sh && \
     export SUBWASM_VERSION=`/version chevdor subwasm` && \
-    cargo install --locked --git https://github.com/chevdor/subwasm --tag ${SUBWASM_VERSION}
+    cargo install --locked --git https://github.com/chevdor/subwasm --tag ${SUBWASM_VERSION} && \
+    export TRY_RUNTIME_VERSION=`/version paritytech try-runtime-cli` && \
+    cargo install --locked --git https://github.com/paritytech/try-runtime-cli --tag ${TRY_RUNTIME_VERSION}

--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,0 +1,1 @@
+Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
           path: snapshots
           key: ${{steps.get_version.outputs.eden_rev}}
       - name: Run try-runtime
-        uses: NodleCode/action-try-runtime@78f23c43b7fa7c89924b148de669c6206bcaaf57
+        uses: NodleCode/action-try-runtime@518ad6cd5b2c81999e440f8d61bfccfafbd87add
         with:
           url: ${{ env.try-runtime-uri}}${{ secrets.DWELLIR_API_KEY}}
           snap: snapshots/eden-snapshot-full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,11 @@ jobs:
         with:
           path: snapshots
           key: ${{steps.get_version.outputs.eden_rev}}
+      - name: Ensure cache directory is created
+        if: steps.cachedir.outputs.cache-hit != 'true'
+        run: |
+          install -d snapshots
+          date > snapshots/created_at
       - name: Run try-runtime
         uses: NodleCode/action-try-runtime@62a47e64e789d1c524d6c3e3c6ef36880a76901f
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
           path: snapshots
           key: ${{steps.get_version.outputs.eden_rev}}
       - name: Run try-runtime
-        uses: NodleCode/action-try-runtime@78f23c4
+        uses: NodleCode/action-try-runtime@78f23c43b7fa7c89924b148de669c6206bcaaf57
         with:
           url: ${{ env.try-runtime-uri}}${{ secrets.DWELLIR_API_KEY}}
           snap: snapshots/eden-snapshot-full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,5 +135,5 @@ jobs:
         with:
           url: ${{ env.try-runtime-uri}}${{ secrets.DWELLIR_API_KEY}}
           snap: snapshots/eden-snapshot-full
-          runtime: target/release/wbuild/runtime-eden/runtime_eden.wasm on-runtime-upgrade
+          runtime: target/release/wbuild/runtime-eden/runtime_eden.wasm
           checks: all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           install -d snapshots
           date > snapshots/created_at
       - name: Run try-runtime
-        uses: NodleCode/action-try-runtime@62a47e64e789d1c524d6c3e3c6ef36880a76901f
+        uses: NodleCode/action-try-runtime@v0
         with:
           url: ${{ env.try-runtime-uri}}${{ secrets.DWELLIR_API_KEY}}
           snap: snapshots/eden-snapshot-full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,16 +128,18 @@ jobs:
         with:
           path: snapshots
           key: ${{steps.get_version.outputs.eden_rev}}
+      - name: Install try-runtime
+        run: cargo install --git https://github.com/paritytech/try-runtime-cli --locked
       - name: Cargo build
-        run: cargo build --release --features=try-runtime --bin nodle-parachain
+        run: cargo build --release --features=try-runtime -p runtime-eden
       - name: Fetch snapshot
         if: steps.cachedir.outputs.cache-hit != 'true'
         continue-on-error: true
         run: |
             install -d snapshots
             date > snapshots/created_at
-            ./target/release/nodle-parachain try-runtime --runtime existing -lruntime=debug --chain ${{ env.try-runtime-chain }} create-snapshot "snapshots/eden-snapshot-full" -u ${{ env.try-runtime-uri}}${{ secrets.DWELLIR_API_KEY}}
+            try-runtime --runtime existing -lruntime=debug create-snapshot --uri ${{ env.try-runtime-uri}}${{ secrets.DWELLIR_API_KEY}} snapshots/eden-snapshot-full
       - name: Try runtime reuse snap
         run: |
             cat snapshots/created_at
-            ./target/release/nodle-parachain try-runtime --runtime target/release/wbuild/runtime-eden/runtime_eden.wasm -lruntime=debug --chain ${{ env.try-runtime-chain }} on-runtime-upgrade --checks=all snap -s snapshots/eden-snapshot-full
+            try-runtime --runtime target/release/wbuild/runtime-eden/runtime_eden.wasm -lruntime=debug on-runtime-upgrade --checks=all snap -s snapshots/eden-snapshot-full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,8 +138,8 @@ jobs:
         run: |
             install -d snapshots
             date > snapshots/created_at
-            try-runtime --runtime existing -lruntime=debug create-snapshot --uri ${{ env.try-runtime-uri}}${{ secrets.DWELLIR_API_KEY}} snapshots/eden-snapshot-full
+            try-runtime --runtime existing create-snapshot --uri ${{ env.try-runtime-uri}}${{ secrets.DWELLIR_API_KEY}} snapshots/eden-snapshot-full
       - name: Try runtime reuse snap
         run: |
             cat snapshots/created_at
-            try-runtime --runtime target/release/wbuild/runtime-eden/runtime_eden.wasm -lruntime=debug on-runtime-upgrade --checks=all snap -s snapshots/eden-snapshot-full
+            try-runtime --runtime target/release/wbuild/runtime-eden/runtime_eden.wasm on-runtime-upgrade --checks=all snap -s snapshots/eden-snapshot-full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,24 +122,18 @@ jobs:
         with:
           toolchain: ${{ env.toolchain }}
           target: ${{ env.target }}
-      - name: Cache a dir
+      - name: Build runtime
+        run: cargo build --release --features=try-runtime -p runtime-eden
+      - name: Setup cache
         uses: actions/cache@v3
         id: cachedir
         with:
           path: snapshots
           key: ${{steps.get_version.outputs.eden_rev}}
-      - name: Install try-runtime
-        run: cargo install --git https://github.com/paritytech/try-runtime-cli --locked
-      - name: Cargo build
-        run: cargo build --release --features=try-runtime -p runtime-eden
-      - name: Fetch snapshot
-        if: steps.cachedir.outputs.cache-hit != 'true'
-        continue-on-error: true
-        run: |
-            install -d snapshots
-            date > snapshots/created_at
-            try-runtime --runtime existing create-snapshot --uri ${{ env.try-runtime-uri}}${{ secrets.DWELLIR_API_KEY}} snapshots/eden-snapshot-full
-      - name: Try runtime reuse snap
-        run: |
-            cat snapshots/created_at
-            try-runtime --runtime target/release/wbuild/runtime-eden/runtime_eden.wasm on-runtime-upgrade --checks=all snap --path snapshots/eden-snapshot-full
+      - name: Run try-runtime
+        uses: NodleCode/action-try-runtime
+        with:
+          url: ${{ env.try-runtime-uri}}${{ secrets.DWELLIR_API_KEY}}
+          snap: snapshots/eden-snapshot-full
+          runtime: target/release/wbuild/runtime-eden/runtime_eden.wasm on-runtime-upgrade
+          checks: all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,4 +142,4 @@ jobs:
       - name: Try runtime reuse snap
         run: |
             cat snapshots/created_at
-            try-runtime --runtime target/release/wbuild/runtime-eden/runtime_eden.wasm on-runtime-upgrade --checks=all snap -s snapshots/eden-snapshot-full
+            try-runtime --runtime target/release/wbuild/runtime-eden/runtime_eden.wasm on-runtime-upgrade --checks=all snap --path snapshots/eden-snapshot-full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
           path: snapshots
           key: ${{steps.get_version.outputs.eden_rev}}
       - name: Run try-runtime
-        uses: NodleCode/action-try-runtime@518ad6cd5b2c81999e440f8d61bfccfafbd87add
+        uses: NodleCode/action-try-runtime@62a47e64e789d1c524d6c3e3c6ef36880a76901f
         with:
           url: ${{ env.try-runtime-uri}}${{ secrets.DWELLIR_API_KEY}}
           snap: snapshots/eden-snapshot-full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
           path: snapshots
           key: ${{steps.get_version.outputs.eden_rev}}
       - name: Run try-runtime
-        uses: NodleCode/action-try-runtime
+        uses: NodleCode/action-try-runtime@78f23c4
         with:
           url: ${{ env.try-runtime-uri}}${{ secrets.DWELLIR_API_KEY}}
           snap: snapshots/eden-snapshot-full

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,7 +1,6 @@
 name: DevContainer
 
 on:
-  workflow_dispatch:
   schedule:
     - cron:  '0 0 * * 0'
 

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,6 +1,7 @@
 name: DevContainer
 
 on:
+  workflow_dispatch:
   schedule:
     - cron:  '0 0 * * 0'
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5365,7 +5365,6 @@ dependencies = [
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
- "try-runtime-cli",
  "xcm",
 ]
 
@@ -12627,7 +12626,6 @@ dependencies = [
  "async-trait",
  "clap",
  "frame-remote-externalities",
- "frame-try-runtime",
  "hex",
  "log",
  "parity-scale-codec",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -20,10 +20,6 @@ runtime-benchmarks = [
 	"runtime-eden/runtime-benchmarks",
 	"polkadot-service/runtime-benchmarks",
 ]
-try-runtime = [
-	"runtime-eden/try-runtime",
-	"try-runtime-cli/try-runtime"
-]
 
 [dependencies]
 clap = { version = "4.1.8", features = ["derive"] }
@@ -42,7 +38,6 @@ primitives = { version = "2.0.17", path = "../primitives" }
 # Substrate Dependencies
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
 frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
-try-runtime-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
 
 pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
 

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -59,13 +59,6 @@ pub enum Subcommand {
 	/// The pallet benchmarking moved to the `pallet` sub-command.
 	#[command(subcommand)]
 	Benchmark(frame_benchmarking_cli::BenchmarkCmd),
-
-	/// Try some testing command against a specified runtime state.
-	#[cfg(feature = "try-runtime")]
-	TryRuntime(try_runtime_cli::TryRuntimeCmd),
-	/// Errors since the binary was not build with `--features try-runtime`.
-	#[cfg(not(feature = "try-runtime"))]
-	TryRuntime,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -247,33 +247,6 @@ pub fn run() -> Result<()> {
 				_ => Err("Benchmarking sub-command unsupported".into()),
 			}
 		}
-		#[cfg(feature = "try-runtime")]
-		Some(Subcommand::TryRuntime(cmd)) => {
-			use sc_executor::{sp_wasm_interface::ExtendedHostFunctions, NativeExecutionDispatch};
-			use try_runtime_cli::block_building_info::timestamp_with_aura_info;
-
-			let runner = cli.create_runner(cmd)?;
-			let registry = &runner.config().prometheus_config.as_ref().map(|cfg| &cfg.registry);
-			let task_manager = sc_service::TaskManager::new(runner.config().tokio_handle.clone(), *registry)
-				.map_err(|e| format!("Error: {:?}", e))?;
-			type HostFunctionsOf<E> = ExtendedHostFunctions<
-				sp_io::SubstrateHostFunctions,
-				<E as NativeExecutionDispatch>::ExtendHostFunctions,
-			>;
-
-			let info_provider = timestamp_with_aura_info(6000);
-
-			runner.async_run(|_| {
-				Ok((
-					cmd.run::<Block, HostFunctionsOf<TemplateRuntimeExecutor>, _>(Some(info_provider)),
-					task_manager,
-				))
-			})
-		}
-		#[cfg(not(feature = "try-runtime"))]
-		Some(Subcommand::TryRuntime) => Err("Try-runtime was not enabled when building the node. \
-			You can enable it with `--features try-runtime`."
-			.into()),
 		Some(Subcommand::Key(cmd)) => Ok(cmd.run(&cli)?),
 		None => {
 			let runner = cli.create_runner(&cli.run.normalize())?;


### PR DESCRIPTION
- [x] confirm `try-runtime` actually works as intended
- [x] remove `try-runtime` command
- [x] check if we need to maintain or remove the `try-runtime` feature flags in the runtime