### PR TITLE
get Nodle parachain ready for state trie migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5432,6 +5432,7 @@ dependencies = [
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
+ "substrate-state-trie-migration-rpc",
  "xcm",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9264,6 +9264,7 @@ dependencies = [
  "pallet-scheduler",
  "pallet-session",
  "pallet-sponsorship",
+ "pallet-state-trie-migration",
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5389,6 +5389,7 @@ dependencies = [
  "hex-literal 0.3.4",
  "jsonrpsee",
  "log",
+ "nodle-rpc-utils",
  "pallet-transaction-payment-rpc",
  "parity-scale-codec",
  "polkadot-cli",
@@ -5434,6 +5435,27 @@ dependencies = [
  "substrate-prometheus-endpoint",
  "substrate-state-trie-migration-rpc",
  "xcm",
+]
+
+[[package]]
+name = "nodle-rpc-utils"
+version = "0.1.0"
+dependencies = [
+ "jsonrpsee",
+ "log",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sc-rpc-api",
+ "scale-info",
+ "serde",
+ "serde_json",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-trie",
+ "trie-db",
 ]
 
 [[package]]
@@ -10661,9 +10683,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0a159d0c45c12b20c5a844feb1fe4bea86e28f17b92a5f0c42193634d3782"
+checksum = "7f7d66a1128282b7ef025a8ead62a4a9fcf017382ec53b8ffbf4d7bf77bd3c60"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10675,9 +10697,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912e55f6d20e0e80d63733872b40e1227c0bce1e1ab81ba67d696339bfd7fd29"
+checksum = "abf2c68b89cafb3b8d918dd07b42be0da66ff202cf1155c5739a4e0c1ea0dc19"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["node", "pallets/*", "primitives", "runtimes/*", "support"]
+members = ["node", "node/rpcs/*", "pallets/*", "primitives", "runtimes/*", "support"]
 resolver = "1"
 
 [profile.release]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -100,6 +100,7 @@ xcm = { git = "https://github.com/paritytech/polkadot", default-features = false
 
 # Temporary
 state-trie-migration-rpc = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42", package = "substrate-state-trie-migration-rpc" }
+nodle-rpc-utils = { path = "./rpcs/utils" }
 
 [dev-dependencies]
 hex-literal = "0.3.4"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -98,5 +98,8 @@ polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch =
 polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.42" }
 xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.42" }
 
+# Temporary
+state-trie-migration-rpc = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42", package = "substrate-state-trie-migration-rpc" }
+
 [dev-dependencies]
 hex-literal = "0.3.4"

--- a/node/rpcs/utils/Cargo.toml
+++ b/node/rpcs/utils/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "nodle-rpc-utils"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
+serde = { version = "1", features = ["derive"] }
+log = { version = "0.4.17", default-features = false }
+
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
+sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
+trie-db = { version = "0.27.1" }
+
+jsonrpsee = { version = "0.16.3", features = ["server", "macros"] }
+
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
+sc-rpc-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
+
+[dev-dependencies]
+serde_json = "1"

--- a/node/rpcs/utils/src/lib.rs
+++ b/node/rpcs/utils/src/lib.rs
@@ -1,0 +1,182 @@
+/*
+ * This file is part of the Nodle Chain distributed at https://github.com/NodleCode/chain
+ * Copyright (C) 2020-2022  Nodle International
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//! Missing RPC utils for Substrate.
+//! Ripped off https://github.com/paritytech/substrate/compare/master...cheme:example_rpc
+//! and brought up to date with current version on substrate.
+
+use jsonrpsee::{
+	core::{Error as JsonRpseeError, RpcResult},
+	proc_macros::rpc,
+	types::error::{CallError, ErrorCode, ErrorObject},
+};
+use sc_rpc_api::DenyUnsafe;
+use serde::{Deserialize, Serialize};
+use sp_runtime::traits::Block as BlockT;
+use std::sync::Arc;
+
+use sp_core::{
+	storage::{ChildInfo, ChildType, PrefixedStorageKey},
+	Hasher,
+};
+use sp_state_machine::backend::AsTrieBackend;
+use sp_trie::{
+	trie_types::{TrieDB, TrieDBBuilder},
+	KeySpacedDB, Trie,
+};
+use trie_db::{
+	node::{NodePlan, ValuePlan},
+	TrieDBNodeIterator,
+};
+
+fn count_migrate<'a, H: Hasher>(
+	storage: &'a dyn trie_db::HashDBRef<H, Vec<u8>>,
+	root: &'a H::Out,
+	max_key_size: &mut usize,
+) -> std::result::Result<(u64, TrieDB<'a, 'a, H>), String> {
+	let mut nb = 0u64;
+	let trie = TrieDBBuilder::new(storage, root).build();
+	let iter_node = TrieDBNodeIterator::new(&trie).map_err(|e| format!("TrieDB node iterator error: {}", e))?;
+	for node in iter_node {
+		let node = node.map_err(|e| format!("TrieDB node iterator error: {}", e))?;
+		match node.2.node_plan() {
+			NodePlan::Leaf { value, partial, .. }
+			| NodePlan::NibbledBranch {
+				value: Some(value),
+				partial,
+				..
+			} => {
+				if let ValuePlan::Inline(range) = value {
+					if (range.end - range.start) as u32 >= sp_core::storage::TRIE_VALUE_NODE_THRESHOLD {
+						nb += 1;
+					}
+				}
+				// false for branch that got an extra nibble but we will always get a bigger leaf
+				// comming after
+				*max_key_size = core::cmp::max((node.0.len() + partial.len()) / 2, *max_key_size);
+			}
+
+			_ => (),
+		}
+	}
+	Ok((nb, trie))
+}
+
+/// Check trie migration status.
+pub fn migration_status<H, B>(backend: &B) -> std::result::Result<(u64, u64, u64), String>
+where
+	H: Hasher,
+	H::Out: codec::Codec,
+	B: AsTrieBackend<H>,
+{
+	let mut max_key_size = 0;
+	let trie_backend = backend.as_trie_backend();
+	let essence = trie_backend.essence();
+	let (nb_to_migrate, trie) = count_migrate(essence, essence.root(), &mut max_key_size)?;
+
+	let mut nb_to_migrate_child = 0;
+	let mut child_roots: Vec<(ChildInfo, Vec<u8>)> = Vec::new();
+	// get all child trie roots
+	for key_value in trie.iter().map_err(|e| format!("TrieDB node iterator error: {}", e))? {
+		let (key, value) = key_value.map_err(|e| format!("TrieDB node iterator error: {}", e))?;
+		if key[..].starts_with(sp_core::storage::well_known_keys::DEFAULT_CHILD_STORAGE_KEY_PREFIX) {
+			let prefixed_key = PrefixedStorageKey::new(key);
+			let (_type, unprefixed) = ChildType::from_prefixed_key(&prefixed_key).unwrap();
+			child_roots.push((ChildInfo::new_default(unprefixed), value));
+		}
+	}
+	for (child_info, root) in child_roots {
+		let mut child_root = H::Out::default();
+		let storage = KeySpacedDB::new(essence, child_info.keyspace());
+
+		child_root.as_mut()[..].copy_from_slice(&root[..]);
+		nb_to_migrate_child += count_migrate(&storage, &child_root, &mut max_key_size)?.0;
+	}
+
+	Ok((nb_to_migrate, nb_to_migrate_child, max_key_size as u64))
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct MigrationStatusResult {
+	top_remaining_to_migrate: u64,
+	child_remaining_to_migrate: u64,
+	max_key_size: u64,
+}
+
+/// Migration RPC methods.
+#[rpc(server)]
+pub trait StateMigrationApi<BlockHash> {
+	/// Check current migration state.
+	///
+	/// This call is performed locally without submitting any transactions. Thus executing this
+	/// won't change any state. Nonetheless it is a VERY costy call that should be
+	/// only exposed to trusted peers.
+	#[method(name = "utils_trieMigrationStatus")]
+	fn call(&self, at: Option<BlockHash>) -> RpcResult<MigrationStatusResult>;
+}
+
+/// An implementation of state migration specific RPC methods.
+pub struct StateMigration<C, B, BA> {
+	client: Arc<C>,
+	backend: Arc<BA>,
+	deny_unsafe: DenyUnsafe,
+	_marker: std::marker::PhantomData<(B, BA)>,
+}
+
+impl<C, B, BA> StateMigration<C, B, BA> {
+	/// Create new state migration rpc for the given reference to the client.
+	pub fn new(client: Arc<C>, backend: Arc<BA>, deny_unsafe: DenyUnsafe) -> Self {
+		StateMigration {
+			client,
+			backend,
+			deny_unsafe,
+			_marker: Default::default(),
+		}
+	}
+}
+
+impl<C, B, BA> StateMigrationApiServer<<B as BlockT>::Hash> for StateMigration<C, B, BA>
+where
+	B: BlockT,
+	C: Send + Sync + 'static + sc_client_api::HeaderBackend<B>,
+	BA: 'static + sc_client_api::backend::Backend<B>,
+{
+	fn call(&self, at: Option<<B as BlockT>::Hash>) -> RpcResult<MigrationStatusResult> {
+		self.deny_unsafe.check_if_safe()?;
+
+		let hash = at.unwrap_or_else(|| self.client.info().best_hash);
+		let state = self.backend.state_at(hash).map_err(error_into_rpc_err)?;
+		let (top, child, max_key_size) = migration_status(&state).map_err(error_into_rpc_err)?;
+
+		Ok(MigrationStatusResult {
+			top_remaining_to_migrate: top,
+			child_remaining_to_migrate: child,
+			max_key_size,
+		})
+	}
+}
+
+fn error_into_rpc_err(err: impl std::fmt::Display) -> JsonRpseeError {
+	JsonRpseeError::Call(CallError::Custom(ErrorObject::owned(
+		ErrorCode::InternalError.code(),
+		"Error while checking migration state",
+		Some(err.to_string()),
+	)))
+}

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -43,7 +43,10 @@ pub struct FullDeps<C, P> {
 }
 
 /// Instantiate all RPC extensions.
-pub fn create_full<C, P, B>(deps: FullDeps<C, P>, backend: Arc<B>) -> Result<RpcExtension, Box<dyn std::error::Error + Send + Sync>>
+pub fn create_full<C, P, B>(
+	deps: FullDeps<C, P>,
+	backend: Arc<B>,
+) -> Result<RpcExtension, Box<dyn std::error::Error + Send + Sync>>
 where
 	C: ProvideRuntimeApi<Block>
 		+ HeaderBackend<Block>

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -77,7 +77,9 @@ where
 
 	// TODO: remove once migration is done
 	use state_trie_migration_rpc::{StateMigration, StateMigrationApiServer};
-	module.merge(StateMigration::new(client, backend, deny_unsafe).into_rpc())?;
+	module.merge(StateMigration::new(client.clone(), backend.clone(), deny_unsafe).into_rpc())?;
+	use nodle_rpc_utils::{StateMigration as UtilsStateMigration, StateMigrationApiServer as UtilsStateMigrationApiServer};
+	module.merge(UtilsStateMigration::new(client, backend, deny_unsafe).into_rpc())?;
 
 	Ok(module)
 }

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -78,7 +78,9 @@ where
 	// TODO: remove once migration is done
 	use state_trie_migration_rpc::{StateMigration, StateMigrationApiServer};
 	module.merge(StateMigration::new(client.clone(), backend.clone(), deny_unsafe).into_rpc())?;
-	use nodle_rpc_utils::{StateMigration as UtilsStateMigration, StateMigrationApiServer as UtilsStateMigrationApiServer};
+	use nodle_rpc_utils::{
+		StateMigration as UtilsStateMigration, StateMigrationApiServer as UtilsStateMigrationApiServer,
+	};
 	module.merge(UtilsStateMigration::new(client, backend, deny_unsafe).into_rpc())?;
 
 	Ok(module)

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -271,6 +271,7 @@ where
 	let rpc_builder = {
 		let client = client.clone();
 		let transaction_pool = transaction_pool.clone();
+		let backend = backend.clone();
 
 		Box::new(move |deny_unsafe, _| {
 			let deps = crate::rpc::FullDeps {
@@ -279,7 +280,7 @@ where
 				deny_unsafe,
 			};
 
-			crate::rpc::create_full(deps).map_err(Into::into)
+			crate::rpc::create_full(deps, backend.clone()).map_err(Into::into)
 		})
 	};
 

--- a/runtimes/eden/Cargo.toml
+++ b/runtimes/eden/Cargo.toml
@@ -235,5 +235,6 @@ pallet-mandate = { default-features = false, path = "../../pallets/mandate" }
 pallet-sponsorship = { default-features = false, path = "../../pallets/sponsorship" }
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.42", default-features = false }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.42", default-features = false }
+
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }

--- a/runtimes/eden/Cargo.toml
+++ b/runtimes/eden/Cargo.toml
@@ -76,6 +76,8 @@ std = [
   "sp-version/std",
   "sp-npos-elections/std",
   "pallet-xcm-benchmarks/std",
+
+  "pallet-state-trie-migration/std",
 ]
 runtime-benchmarks = [
   "frame-benchmarking/runtime-benchmarks",
@@ -104,6 +106,8 @@ runtime-benchmarks = [
   "pallet-xcm-benchmarks/runtime-benchmarks",
   "cumulus-pallet-xcmp-queue/runtime-benchmarks",
   "sp-runtime/runtime-benchmarks",
+
+  "pallet-state-trie-migration/runtime-benchmarks",
 ]
 try-runtime = [
   "frame-executive/try-runtime",
@@ -142,6 +146,8 @@ try-runtime = [
   "pallet-xcm/try-runtime",
   "parachain-info/try-runtime",
   "orml-xtokens/try-runtime",
+
+  "pallet-state-trie-migration/try-runtime",
 ]
 
 [dependencies]
@@ -174,6 +180,7 @@ pallet-insecure-randomness-collective-flip = { git = "https://github.com/parityt
 pallet-scheduler = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 pallet-preimage = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
+pallet-state-trie-migration = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }
 pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.42" }

--- a/runtimes/eden/src/lib.rs
+++ b/runtimes/eden/src/lib.rs
@@ -124,6 +124,10 @@ construct_runtime! {
 
 		// Smart Contracts.
 		Contracts: pallet_contracts = 62,
+
+		// TODO: remove once state trie migration is done
+		// Temporary
+		StateTrieMigration: pallet_state_trie_migration = 99,
 	}
 }
 /// The address format for describing accounts.
@@ -378,6 +382,8 @@ sp_api::impl_runtime_apis! {
 			list_benchmark!(list, extra, pallet_xcm_benchmarks::generic, XcmGenericBenchmarks);
 			list_benchmark!(list, extra, pallet_xcm_benchmarks::fungible, XcmFungibleBenchmarks);
 
+			list_benchmark!(list, extra, pallet_state_trie_migration, StateTrieMigration);
+
 			let storage_info = AllPalletsWithSystem::storage_info();
 
 			(list, storage_info)
@@ -419,6 +425,8 @@ sp_api::impl_runtime_apis! {
 			add_benchmark!(params, batches, pallet_xcm, PolkadotXcm);
 			add_benchmark!(params, batches, pallet_xcm_benchmarks::generic, XcmGenericBenchmarks);
 			add_benchmark!(params, batches, pallet_xcm_benchmarks::fungible, XcmFungibleBenchmarks);
+
+			add_benchmark!(list, extra, pallet_state_trie_migration, StateTrieMigration);
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)

--- a/runtimes/eden/src/lib.rs
+++ b/runtimes/eden/src/lib.rs
@@ -426,7 +426,7 @@ sp_api::impl_runtime_apis! {
 			add_benchmark!(params, batches, pallet_xcm_benchmarks::generic, XcmGenericBenchmarks);
 			add_benchmark!(params, batches, pallet_xcm_benchmarks::fungible, XcmFungibleBenchmarks);
 
-			add_benchmark!(list, extra, pallet_state_trie_migration, StateTrieMigration);
+			add_benchmark!(params, batches, pallet_state_trie_migration, StateTrieMigration);
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)

--- a/runtimes/eden/src/pallets_system.rs
+++ b/runtimes/eden/src/pallets_system.rs
@@ -195,8 +195,10 @@ parameter_types! {
 	pub const MigrationSignedDepositPerItem: Balance = 1 * constants::NANO_NODL;
 	pub const MigrationSignedDepositBase: Balance = 1 * constants::NANO_NODL;
 
-	// TODO: define via https://github.com/paritytech/substrate/issues/11642
-	pub const MaxKeyLen: u32 = 512;
+	// To obtain this value, run a node via `cargo run --release -- --tmp --sync=warp --rpc-methods=unsafe -- --tmp --sync=warp`
+	// and trigger the appropriate RPC `utils_trieMigrationStatus` call.
+	// `echo '{"id":1,"jsonrpc":"2.0","method":"utils_trieMigrationStatus","params":[]}' | websocat -n1 -B 99999999 ws://127.0.0.1:9944`
+	pub const MaxKeyLen: u32 = 120;
 }
 impl pallet_state_trie_migration::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;

--- a/runtimes/eden/src/pallets_system.rs
+++ b/runtimes/eden/src/pallets_system.rs
@@ -188,9 +188,12 @@ where
 
 // TODO: remove this once state trie migration is done.
 parameter_types! {
-	// The deposit configuration for the singed migration. Specially if you want to allow any signed account to do the migration (see `SignedFilter`, these deposits should be high)
+	// The deposit configuration for the singed migration. These deposits are futile given we only
+	// allow Technical Committee members to kick-in the migration, as such we can safely lower them.
+	//
+	// I have not set them to 0 in case of any unexpected behavior in the code.
 	pub const MigrationSignedDepositPerItem: Balance = 1 * constants::NANO_NODL;
-	pub const MigrationSignedDepositBase: Balance = 20 * constants::NODL;
+	pub const MigrationSignedDepositBase: Balance = 1 * constants::NANO_NODL;
 
 	// TODO: define via https://github.com/paritytech/substrate/issues/11642
 	pub const MaxKeyLen: u32 = 512;

--- a/runtimes/eden/src/pallets_system.rs
+++ b/runtimes/eden/src/pallets_system.rs
@@ -185,3 +185,30 @@ where
 	type OverarchingCall = RuntimeCall;
 	type Extrinsic = UncheckedExtrinsic;
 }
+
+// TODO: remove this once state trie migration is done.
+parameter_types! {
+	// The deposit configuration for the singed migration. Specially if you want to allow any signed account to do the migration (see `SignedFilter`, these deposits should be high)
+	pub const MigrationSignedDepositPerItem: Balance = 1 * constants::NANO_NODL;
+	pub const MigrationSignedDepositBase: Balance = 20 * constants::NODL;
+
+	// TODO: define via https://github.com/paritytech/substrate/issues/11642
+	pub const MaxKeyLen: u32 = 512;
+}
+impl pallet_state_trie_migration::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type Currency = Balances;
+	type SignedDepositPerItem = MigrationSignedDepositPerItem;
+	type SignedDepositBase = MigrationSignedDepositBase;
+	type MaxKeyLen = MaxKeyLen;
+
+	// The configuration below allows ANY member from the Technical Committee
+	// to trigger the migration.
+	// This is considered safe as the migration is temporary and needs manual
+	// activation through a series of extrinsic calls to make it progress.
+	type ControlOrigin = pallet_collective::EnsureMember<AccountId, pallet_collective::Instance1>;
+	type SignedFilter = pallet_collective::EnsureMember<AccountId, pallet_collective::Instance1>;
+
+	// Replace this with weight based on your runtime.
+	type WeightInfo = (); // TODO: add weight for migration
+}

--- a/runtimes/eden/src/version.rs
+++ b/runtimes/eden/src/version.rs
@@ -54,7 +54,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	transaction_version: 5,
 
 	apis: RUNTIME_API_VERSIONS,
-	state_version: 0,
+	state_version: 1,
 };
 
 /// The version infromation used to identify this runtime when compiled natively.

--- a/runtimes/eden/src/version.rs
+++ b/runtimes/eden/src/version.rs
@@ -40,7 +40,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	/// Version of the runtime specification. A full-node will not attempt to use its native
 	/// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
 	/// `spec_version` and `authoring_version` are the same between Wasm and native.
-	spec_version: 25,
+	spec_version: 26,
 
 	/// Version of the implementation of the specification. Nodes are free to ignore this; it
 	/// serves only as an indication that the code is different; as long as the other two versions

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -5,7 +5,8 @@ STEPS="${1:-50}"
 REPEAT="${2:-20}"
 
 export external="frame_system pallet_balances pallet_collator_selection pallet_contracts pallet_membership\
- pallet_multisig pallet_preimage pallet_scheduler pallet_timestamp pallet_uniques pallet_utility pallet_xcm"
+ pallet_multisig pallet_preimage pallet_scheduler pallet_timestamp pallet_uniques pallet_utility pallet_xcm\
+ pallet_state_trie_migration"
 export internal="pallet_allocations pallet_grants pallet_reserve pallet_nodle_uniques pallet_sponsorship"
 export xcm_generic_extrinsic="report_holding, buy_execution, query_response, transact, refund_surplus,\
  set_error_handler, set_appendix, clear_error, descend_origin, clear_origin, report_error, claim_asset, trap, \


### PR DESCRIPTION
It appears we never fully completed the State Trie migration from prior versions of Substrate. ~~Not doing so seems to be preventing correct usage of the Warp sync mode which could save us a lot of money on node storage and syncing time.~~ Additionally it appears the new State Trie format may help reducing the PoV size for Parachain blocks which is what posed us issues last month.

This PR adds the right RPC, pallet, and version changes for performing the state migration manually, potentially via [Parity's script](https://github.com/paritytech/polkadot-scripts/blob/master/src/services/state_trie_migration.ts). More information in [this great HackMD](https://hackmd.io/@kizi/HyoSO3lf9). The changes from this PR can be safely reverted post migration.

The entire migration flow which includes setting transaction limits and running the **full** migration via the prior mentioned script or a fork should be fully tested end to end on the testnet prior to main net usage. Nonetheless, it appears this is a relatively safe migration since Substrate will operate in "hybrid" mode (not warp compatible) by default until we complete the migration via the script. If the script, is not run, or simply does not work, the migration will be done opportunistically, meaning that Substrate will migrate storage values as they are accessed on the fly. (In fact the script / pallet combination simply iterates through every storage values by reading them as per my understanding - correct me if I am wrong).

### Remaining TODOs
- [ ] add benchmarks
- [x] find the right safe `MaxKeysLen` value

### Post deployment sanity checks
- ensure `utils_trieMigrationStatus` still return a `MaxKeyLen` of no higher than 120
- ensure we can run the signed migration via the bot for all of the chain without errors

In case of any failure we can simply make a new runtime upgrade to increase `MaxKeyLen`, or resume the migration after a script fix which wouldn't require a runtime upgrade.