### PR TITLE
chore: allow us to run some CI jobs manually when we need

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,15 @@ on:
     branches:
       - master
   pull_request:
-
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to run the workflow on'
+        required: true
+      run_specific_job:
+        description: 'Specify a job to run (test-runtime, try-runtime-execute, etc.)'
+        required: true
+  
 env:
   toolchain: stable
   target: wasm32-unknown-unknown


### PR DESCRIPTION
We will need to re-run try-runtime tests later for a specific tag (release) close to the deployment time.