### PR TITLE
Improve stability for try-runtime flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
           out-file-path: "snaps"
           extract: false
       - name: Run try-runtime
-        uses: NodleCode/action-try-runtime/check@beta
+        uses: NodleCode/action-try-runtime/check@v0.6.1
         with:
           snap: snaps/eden-snapshot-full
           runtime: target/release/wbuild/runtime-eden/runtime_eden.wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           fail_ci_if_error: false
           files: lcov.info
 
-  try-runtime-prepare:
+  try-runtime:
     runs-on: ubuntu-latest
 
     steps:
@@ -134,9 +134,6 @@ jobs:
           fileName: "eden-snapshot-full"
           out-file-path: "snaps"
           extract: false
-      - name: Check files
-        run: |
-           md5sum snaps/eden-snapshot-full
       - name: Run try-runtime
         uses: NodleCode/action-try-runtime/check@beta
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,27 +143,20 @@ jobs:
              }' | jq .result.specVersion | sed 's/^/try-runtime-snapshot-eden-spec-/' >> $GITHUB_OUTPUT
            cat $GITHUB_OUTPUT
         id: get_version
-      - name: Setup cache
-        uses: actions/cache@v3
-        id: cachedir
-        with:
-          path: snapshots
-          key: ${{steps.get_version.outputs.eden_rev}}
-      - name: Ensure cache directory is created
-        if: steps.cachedir.outputs.cache-hit != 'true'
+      - uses: robinraju/release-downloader@v1.9
+        with: 
+          repository: "NodleCode/eden-snapshot"
+          latest: true
+          fileName: "eden-snapshot-full"
+          out-file-path: "snaps"
+          extract: false
+      - name: Check files
         run: |
-          install -d snapshots
-          date > snapshots/created_at
+           md5sum snaps/eden-snapshot-full
       - name: Run try-runtime
-        uses: NodleCode/action-try-runtime@v0.5.1
+        uses: NodleCode/action-try-runtime/check@beta
         with:
-          url: ${{ env.try-runtime-uri}}${{ secrets.DWELLIR_API_KEY}}
-          snap: snapshots/eden-snapshot-full
+          snap: snaps/eden-snapshot-full
           runtime: try_runtime/runtime_eden.wasm
           checks: "all"
           options: "--disable-idempotency-checks"
-      - name: Upload snap artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: edensnap
-          path: snapshots/eden-snapshot-full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Build runtime
         run: cargo build --release --features=try-runtime -p runtime-eden
       - name: Upload runtime artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: try_runtime
           path: target/release/wbuild/runtime-eden/runtime_eden.wasm
@@ -128,7 +128,7 @@ jobs:
 
     steps:
       - name: Download runtime artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: try_runtime
           path: try_runtime

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           files: lcov.info
 
   try-runtime-prepare:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -116,22 +116,6 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.4
       - name: Build runtime
         run: cargo build --release --features=try-runtime -p runtime-eden
-      - name: Upload runtime artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: try_runtime
-          path: target/release/wbuild/runtime-eden/runtime_eden.wasm
-
-  try-runtime-execute:
-    runs-on: ubuntu-latest
-    needs: try-runtime-prepare
-
-    steps:
-      - name: Download runtime artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: try_runtime
-          path: try_runtime
       - name: Check Version
         run: |
           echo -n "eden_rev=" >> $GITHUB_OUTPUT
@@ -157,6 +141,6 @@ jobs:
         uses: NodleCode/action-try-runtime/check@beta
         with:
           snap: snaps/eden-snapshot-full
-          runtime: try_runtime/runtime_eden.wasm
+          runtime: target/release/wbuild/runtime-eden/runtime_eden.wasm
           checks: "all"
           options: "--disable-idempotency-checks"

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -8,6 +8,8 @@ env:
 on:
   push:
     branches: master
+  pull_request: 
+    branches: master
 
 jobs:
   autodoc:
@@ -23,6 +25,7 @@ jobs:
       - name: Build the docs
         run: cargo doc --all --no-deps
       - name: Deploy the docs
+        if: github.event_name != 'pull_request'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           toolchain: stable
           components: rust-src
+          target: wasm32-unknown-unknown
       - name: Install protobuf-compiler
         run: |
           sudo apt-get install protobuf-compiler

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -16,7 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: rustup show
+      - name: Install Rust stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: rust-src
       - name: Install protobuf-compiler
         run: |
           sudo apt-get install protobuf-compiler

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -3,6 +3,7 @@ name: Rust AutoDoc
 env:
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
+  RUSTFLAGS: "-A warnings"
 
 
 on:


### PR DESCRIPTION
- Try runtime will take about one minute to check every time now. Before there could be a penalty of 10-15 minutes if the snap was not in the cache and if the test failed the cache would not have been updated so the next check would also be slow.
- Executor size for try-runtime is reduced from 8 core to standard. 
- doc generation is tested on every PR, and ignores warning. (Autodoc is not the place to notify us about warnings)