### PR TITLE
feat(runtime-eden): add bridge_all_vesting_schedules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6459,6 +6459,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "hex-literal",
  "log",
  "pallet-balances",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["node", "pallets/*", "primitives", "runtimes/*", "support"]
 resolver = "1"
 
 [workspace.package]
-version= "2.5.3"
+version = "2.5.3"
 authors = ["Nodle Developers <eng@nodle.com>"]
 edition = "2021"
 
@@ -28,7 +28,7 @@ cumulus-primitives-core = { version = "0.7.0", default-features = false }
 cumulus-primitives-parachain-inherent = { version = "0.7.0", default-features = false }
 cumulus-primitives-timestamp = { version = "0.7.0", default-features = false }
 cumulus-primitives-utility = { version = "0.7.0", default-features = false }
-cumulus-client-consensus-proposer = { version = "0.7.0", default-features = false}
+cumulus-client-consensus-proposer = { version = "0.7.0", default-features = false }
 cumulus-relay-chain-inprocess-interface = { version = "0.7.0", default-features = false }
 cumulus-relay-chain-interface = { version = "0.7.0", default-features = false }
 cumulus-relay-chain-rpc-interface = { version = "0.7.0", default-features = false }
@@ -103,7 +103,7 @@ sp-core = { version = "28.0.0", default-features = false }
 sp-inherents = { version = "26.0.0", default-features = false }
 sp-io = { version = "30.0.0", default-features = false }
 sp-keystore = { version = "0.34.0", default-features = false }
-sp-genesis-builder = { version = "0.7.0", default-features = false}
+sp-genesis-builder = { version = "0.7.0", default-features = false }
 sp-npos-elections = { version = "26.0.0", default-features = false }
 sp-offchain = { version = "26.0.0", default-features = false }
 sp-runtime = { version = "31.0.0", default-features = false }
@@ -119,9 +119,9 @@ sp-version = { version = "29.0.0", default-features = false }
 substrate-build-script-utils = { version = "11.0.0", default-features = false }
 substrate-prometheus-endpoint = { version = "0.17.0", default-features = false }
 substrate-wasm-builder = { version = "17.0.0", default-features = false }
-xcm-builder = { package="staging-xcm-builder", version = "7.0.0", default-features = false }
-xcm-executor = { package="staging-xcm-executor", version = "7.0.0", default-features = false }
-xcm = { package = "staging-xcm", version = "7.0.0", default-features = false}
+xcm-builder = { package = "staging-xcm-builder", version = "7.0.0", default-features = false }
+xcm-executor = { package = "staging-xcm-executor", version = "7.0.0", default-features = false }
+xcm = { package = "staging-xcm", version = "7.0.0", default-features = false }
 
 #ORML
 orml-xtokens = { version = "0.7.0", default-features = false }
@@ -129,15 +129,19 @@ orml-traits = { version = "0.7.0", default-features = false }
 
 #Crates
 clap = { version = "4.1.8", features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false}
+codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false }
 derive_more = "0.99.2"
 getrandom = { version = "0.2", features = ["js"] }
 hex-literal = { version = "0.4.1" }
 jsonrpsee = { version = "0.16.2", features = ["server"] }
-lazy_static = {version = "1.4.0", default-features = false, features = ["spin_no_std"] }
+lazy_static = { version = "1.4.0", default-features = false, features = [
+    "spin_no_std",
+] }
 log = { version = "0.4.17", default-features = false }
 safe-mix = { version = "1.0.1", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5.0", default-features = false, features = [
+    "derive",
+] }
 serde = { version = "1.0.152", default-features = false }
 serde_json = { version = "1.0.104", default-features = false }
 static_assertions = "1.1.0"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,7 +24,7 @@ runtime-benchmarks = [
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 derive_more.workspace = true
-log = { workspace = true, default-features = true}
+log = { workspace = true, default-features = true }
 codec.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
@@ -99,7 +99,6 @@ polkadot-cli.workspace = true
 polkadot-parachain-primitives.workspace = true
 polkadot-primitives.workspace = true
 polkadot-service.workspace = true
-xcm = { workspace = true, default-features = false}
-hex-literal = "0.4.1"
-[dev-dependencies]
-hex-literal = {workspace = true }
+xcm = { workspace = true, default-features = false }
+
+hex-literal = { workspace = true }

--- a/pallets/grants/Cargo.toml
+++ b/pallets/grants/Cargo.toml
@@ -16,6 +16,8 @@ std = [
 	"codec/std",
 	"serde",
 	"frame-support/std",
+	"frame-benchmarking/std",
+
 	"frame-system/std",
 	"pallet-balances/std",
 	"sp-runtime/std",
@@ -25,6 +27,7 @@ std = [
 runtime-benchmarks = [
 	"frame-benchmarking",
 	"frame-system/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 ]
 try-runtime = ["frame-support/try-runtime"]
@@ -43,8 +46,8 @@ pallet-balances = { workspace = true, default-features = false }
 sp-io = { workspace = true, default-features = false }
 sp-runtime = { workspace = true, default-features = false }
 sp-std = { workspace = true, default-features = false }
+hex-literal = { workspace = true }
 
 [dev-dependencies]
 sp-core = { workspace = true, default-features = false }
 sp-tracing = { workspace = true, default-features = false }
-hex-literal = { workspace = true }

--- a/pallets/grants/Cargo.toml
+++ b/pallets/grants/Cargo.toml
@@ -33,7 +33,9 @@ try-runtime = ["frame-support/try-runtime"]
 log = { workspace = true, default-features = false }
 codec = { workspace = true, default-features = false, features = ["derive"] }
 serde = { workspace = true, optional = true }
-scale-info = { workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = [
+	"derive",
+] }
 frame-benchmarking = { workspace = true, default-features = false, optional = true }
 frame-support = { workspace = true, default-features = false }
 frame-system = { workspace = true, default-features = false }
@@ -45,4 +47,4 @@ sp-std = { workspace = true, default-features = false }
 [dev-dependencies]
 sp-core = { workspace = true, default-features = false }
 sp-tracing = { workspace = true, default-features = false }
-
+hex-literal = { workspace = true }

--- a/pallets/grants/src/benchmarking.rs
+++ b/pallets/grants/src/benchmarking.rs
@@ -25,6 +25,7 @@ use crate::Pallet as Grants;
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, BenchmarkError};
 use frame_support::traits::{EnsureOrigin, Get, UnfilteredDispatchable};
 use frame_system::RawOrigin;
+use hex_literal::hex;
 use sp_runtime::traits::Bounded;
 use sp_std::prelude::*;
 
@@ -98,7 +99,16 @@ benchmarks! {
 		let origin = T::CancelOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
 	}: { call.dispatch_bypass_filter(origin)? }
 
-	renounce {
+	bridge_all_vesting_schedules {
+		let config = create_shared_config::<T>(1);
+
+		 for _x in 1 .. T::MaxSchedule::get() {
+			 Pallet::<T>::do_add_vesting_schedule(&config.granter, &config.grantee, config.schedule.clone())?;
+		 }
+
+	 }: _(RawOrigin::Signed(config.grantee.clone()), hex!("2E7F3926Ae74FDCDcAde2c2AB50990C5daFD42bD"), 300)
+
+	 renounce {
 		let config = create_shared_config::<T>(1);
 		let call = Call::<T>::renounce{
 			who: config.grantee_lookup,

--- a/pallets/grants/src/benchmarking.rs
+++ b/pallets/grants/src/benchmarking.rs
@@ -101,12 +101,29 @@ benchmarks! {
 
 	bridge_all_vesting_schedules {
 		let config = create_shared_config::<T>(1);
+		let bridge_name = b"zklocal";
+		let bridge_id = 1;
+		let remote_chain_id = 9924;
+		Pallet::<T>::set_bridge(RawOrigin::Root.into(), bridge_id, bridge_name.to_vec(), remote_chain_id)?;
 
 		 for _x in 1 .. T::MaxSchedule::get() {
 			 Pallet::<T>::do_add_vesting_schedule(&config.granter, &config.grantee, config.schedule.clone())?;
 		 }
 
-	 }: _(RawOrigin::Signed(config.grantee.clone()), hex!("2E7F3926Ae74FDCDcAde2c2AB50990C5daFD42bD"), 300)
+	 }: _(RawOrigin::Signed(config.grantee.clone()), hex!("2E7F3926Ae74FDCDcAde2c2AB50990C5daFD42bD"), bridge_id)
+
+	 set_bridge {
+		let bridge_name = b"bridge_between_eden_zks_main_era";
+		let bridge_id = 1;
+		let remote_chain_id = 300;
+	}: _(RawOrigin::Root, bridge_id, bridge_name.to_vec(), remote_chain_id)
+
+	remove_bridge {
+		let bridge_name = b"bridge_between_eden_zks_main_era";
+		let bridge_id = 1;
+		let remote_chain_id = 300;
+		Pallet::<T>::set_bridge(RawOrigin::Root.into(), bridge_id, bridge_name.to_vec(), remote_chain_id)?;
+	}: _(RawOrigin::Root, bridge_id)
 
 	 renounce {
 		let config = create_shared_config::<T>(1);

--- a/pallets/grants/src/lib.rs
+++ b/pallets/grants/src/lib.rs
@@ -243,7 +243,6 @@ pub mod pallet {
 				Error::<T>::BridgeNotFound
 			);
 
-			ensure!(!Self::renounced(from.clone()), Error::<T>::Renounced);
 			let locked_amount_left = Self::do_claim(&from);
 			if locked_amount_left.is_zero() {
 				<VestingSchedules<T>>::remove(from);

--- a/pallets/grants/src/tests.rs
+++ b/pallets/grants/src/tests.rs
@@ -289,6 +289,15 @@ fn cancel_auto_claim_recipient_funds_and_wire_the_rest() {
 #[test]
 fn bridge_all_vesting_schedules_does_claim_first() {
 	ExtBuilder::default().one_hundred_for_alice().build().execute_with(|| {
+		let bridge_id = 1;
+		let bridge_name = b"zklocal";
+		let remote_chain_id = 9924;
+		assert_ok!(Vesting::set_bridge(
+			RuntimeOrigin::root(),
+			bridge_id,
+			bridge_name.into(),
+			remote_chain_id
+		));
 		let schedule = VestingSchedule {
 			start: 0u64,
 			period: 10u64,
@@ -308,7 +317,7 @@ fn bridge_all_vesting_schedules_does_claim_first() {
 		assert_ok!(Vesting::bridge_all_vesting_schedules(
 			RuntimeOrigin::signed(BOB::get()),
 			hex!("2E7F3926Ae74FDCDcAde2c2AB50990C5daFD42bD"),
-			300
+			bridge_id
 		));
 		assert_eq!(PalletBalances::free_balance(BOB::get()), 10);
 		assert_eq!(PalletBalances::usable_balance(BOB::get()), 10);
@@ -318,6 +327,15 @@ fn bridge_all_vesting_schedules_does_claim_first() {
 #[test]
 fn bridge_all_vesting_schedules_clears_storage() {
 	ExtBuilder::default().one_hundred_for_alice().build().execute_with(|| {
+		let bridge_id = 1;
+		let bridge_name = b"zklocal";
+		let remote_chain_id = 9924;
+		assert_ok!(Vesting::set_bridge(
+			RuntimeOrigin::root(),
+			bridge_id,
+			bridge_name.into(),
+			remote_chain_id
+		));
 		let schedule = VestingSchedule {
 			start: 0u64,
 			period: 10u64,
@@ -336,7 +354,7 @@ fn bridge_all_vesting_schedules_clears_storage() {
 		assert_ok!(Vesting::bridge_all_vesting_schedules(
 			RuntimeOrigin::signed(BOB::get()),
 			hex!("2E7F3926Ae74FDCDcAde2c2AB50990C5daFD42bD"),
-			300
+			bridge_id
 		));
 		assert!(!<VestingSchedules<Runtime>>::contains_key(BOB::get()));
 		assert!(!<Renounced<Runtime>>::contains_key(BOB::get()));
@@ -346,6 +364,15 @@ fn bridge_all_vesting_schedules_clears_storage() {
 #[test]
 fn bridge_all_vesting_schedules_reduces_total_issuance() {
 	ExtBuilder::default().one_hundred_for_alice().build().execute_with(|| {
+		let bridge_id = 1;
+		let bridge_name = b"zklocal";
+		let remote_chain_id = 9924;
+		assert_ok!(Vesting::set_bridge(
+			RuntimeOrigin::root(),
+			bridge_id,
+			bridge_name.into(),
+			remote_chain_id
+		));
 		let schedule = VestingSchedule {
 			start: 0u64,
 			period: 10u64,
@@ -364,7 +391,7 @@ fn bridge_all_vesting_schedules_reduces_total_issuance() {
 		assert_ok!(Vesting::bridge_all_vesting_schedules(
 			RuntimeOrigin::signed(BOB::get()),
 			hex!("2E7F3926Ae74FDCDcAde2c2AB50990C5daFD42bD"),
-			300
+			bridge_id
 		));
 		assert_eq!(PalletBalances::total_issuance(), 90);
 	});
@@ -373,6 +400,15 @@ fn bridge_all_vesting_schedules_reduces_total_issuance() {
 #[test]
 fn bridge_all_vesting_schedules_emits_expected_event() {
 	ExtBuilder::default().one_hundred_for_alice().build().execute_with(|| {
+		let bridge_id = 1;
+		let bridge_name = b"zklocal";
+		let remote_chain_id = 9924;
+		assert_ok!(Vesting::set_bridge(
+			RuntimeOrigin::root(),
+			bridge_id,
+			bridge_name.into(),
+			remote_chain_id
+		));
 		let schedule1 = VestingSchedule {
 			start: 0u64,
 			period: 10u64,
@@ -401,7 +437,7 @@ fn bridge_all_vesting_schedules_emits_expected_event() {
 		assert_ok!(Vesting::bridge_all_vesting_schedules(
 			RuntimeOrigin::signed(BOB::get()),
 			hex!("2E7F3926Ae74FDCDcAde2c2AB50990C5daFD42bD"),
-			300
+			bridge_id
 		));
 		let remaining_grants = BoundedVec::try_from(vec![schedule1, schedule2]).unwrap();
 
@@ -409,7 +445,7 @@ fn bridge_all_vesting_schedules_emits_expected_event() {
 			System::events().last().unwrap().event,
 			TestEvent::Vesting(Event::BridgeInitiated {
 				to: hex!("2E7F3926Ae74FDCDcAde2c2AB50990C5daFD42bD"),
-				chain_id: 300,
+				bridge_id: 1,
 				amount: 17,
 				grants: remaining_grants,
 			})
@@ -420,6 +456,15 @@ fn bridge_all_vesting_schedules_emits_expected_event() {
 #[test]
 fn bridge_all_vesting_schedules_completes_one_sidedly_when_no_grants_after_claim() {
 	ExtBuilder::default().one_hundred_for_alice().build().execute_with(|| {
+		let bridge_id = 1;
+		let bridge_name = b"zklocal";
+		let remote_chain_id = 9924;
+		assert_ok!(Vesting::set_bridge(
+			RuntimeOrigin::root(),
+			bridge_id,
+			bridge_name.into(),
+			remote_chain_id
+		));
 		let schedule = VestingSchedule {
 			start: 0u64,
 			period: 10u64,
@@ -437,12 +482,82 @@ fn bridge_all_vesting_schedules_completes_one_sidedly_when_no_grants_after_claim
 		assert_ok!(Vesting::bridge_all_vesting_schedules(
 			RuntimeOrigin::signed(BOB::get()),
 			hex!("2E7F3926Ae74FDCDcAde2c2AB50990C5daFD42bD"),
-			300
+			bridge_id
 		));
 		assert_eq!(PalletBalances::usable_balance(BOB::get()), 100);
 		assert_eq!(
 			System::events().last().unwrap().event,
 			TestEvent::Vesting(Event::NoVestedFundsToBridgeAfterClaim)
+		);
+	});
+}
+
+#[test]
+fn set_bridge_fails_if_bridge_already_exists() {
+	ExtBuilder::default().build().execute_with(|| {
+		let bridge_id = 1;
+		let bridge_name = b"zklocal";
+		let remote_chain_id = 9924;
+		assert_ok!(Vesting::set_bridge(
+			RuntimeOrigin::root(),
+			bridge_id,
+			bridge_name.into(),
+			remote_chain_id
+		));
+		assert_err!(
+			Vesting::set_bridge(RuntimeOrigin::root(), bridge_id, bridge_name.into(), remote_chain_id),
+			Error::<Runtime>::BridgeAlreadyExists
+		);
+	});
+}
+
+#[test]
+fn remove_bridge_works() {
+	ExtBuilder::default().build().execute_with(|| {
+		let bridge_id = 1;
+		let bridge_name = b"zklocal";
+		let remote_chain_id = 9924;
+		assert_ok!(Vesting::set_bridge(
+			RuntimeOrigin::root(),
+			bridge_id,
+			bridge_name.into(),
+			remote_chain_id
+		));
+		let details = <Bridges<Runtime>>::get(BridgeId(bridge_id)).unwrap();
+		assert_eq!(
+			details,
+			BridgeDetails {
+				name: bridge_name.to_vec().try_into().unwrap(),
+				chain_id: remote_chain_id
+			}
+		);
+		assert_ok!(Vesting::remove_bridge(RuntimeOrigin::root(), bridge_id));
+		assert!(!<Bridges<Runtime>>::contains_key(BridgeId(bridge_id)));
+	});
+}
+
+#[test]
+fn remove_bridge_fails_if_bridge_not_found() {
+	ExtBuilder::default().build().execute_with(|| {
+		let bridge_id = 1;
+		assert_err!(
+			Vesting::remove_bridge(RuntimeOrigin::root(), bridge_id),
+			Error::<Runtime>::BridgeNotFound
+		);
+	});
+}
+
+#[test]
+fn bridge_all_vesting_schedules_fails_if_no_bridge() {
+	ExtBuilder::default().one_hundred_for_alice().build().execute_with(|| {
+		let bridge_id = 1;
+		assert_err!(
+			Vesting::bridge_all_vesting_schedules(
+				RuntimeOrigin::signed(BOB::get()),
+				hex!("2E7F3926Ae74FDCDcAde2c2AB50990C5daFD42bD"),
+				bridge_id
+			),
+			Error::<Runtime>::BridgeNotFound
 		);
 	});
 }

--- a/pallets/grants/src/tests.rs
+++ b/pallets/grants/src/tests.rs
@@ -512,6 +512,48 @@ fn set_bridge_fails_if_bridge_already_exists() {
 }
 
 #[test]
+fn set_bridge_fails_if_name_too_long() {
+	ExtBuilder::default().build().execute_with(|| {
+		let bridge_id = 1;
+		let bridge_name = b"somereallylonglonglongnnnnnnnnameeee";
+		let remote_chain_id = 9924;
+		assert_err!(
+			Vesting::set_bridge(RuntimeOrigin::root(), bridge_id, bridge_name.into(), remote_chain_id),
+			Error::<Runtime>::BridgeNameTooLong
+		);
+	});
+}
+
+#[test]
+fn set_bridge_fails_if_non_root() {
+	ExtBuilder::default().build().execute_with(|| {
+		let bridge_id = 1;
+		let bridge_name = b"zklocal";
+		let remote_chain_id = 9924;
+		assert_err!(
+			Vesting::set_bridge(
+				RuntimeOrigin::signed(ALICE::get()),
+				bridge_id,
+				bridge_name.into(),
+				remote_chain_id
+			),
+			BadOrigin
+		);
+	});
+}
+
+#[test]
+fn remove_bridge_fails_if_non_root() {
+	ExtBuilder::default().build().execute_with(|| {
+		let bridge_id = 1;
+		assert_err!(
+			Vesting::remove_bridge(RuntimeOrigin::signed(ALICE::get()), bridge_id),
+			BadOrigin
+		);
+	});
+}
+
+#[test]
 fn remove_bridge_works() {
 	ExtBuilder::default().build().execute_with(|| {
 		let bridge_id = 1;

--- a/pallets/grants/src/weights.rs
+++ b/pallets/grants/src/weights.rs
@@ -105,12 +105,23 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(8_u64))
 			.saturating_add(T::DbWeight::get().writes(5_u64))
 	}
-	// TODO redo benchmarking
+	// Storage: `ParachainSystem::ValidationData` (r:1 w:0)
+	// Proof: `ParachainSystem::ValidationData` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	// Storage: `Vesting::VestingSchedules` (r:1 w:1)
+	// Proof: `Vesting::VestingSchedules` (`max_values`: None, `max_size`: Some(2850), added: 5325, mode: `MaxEncodedLen`)
+	// Storage: `Balances::Locks` (r:1 w:1)
+	// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	// Storage: `Balances::Freezes` (r:1 w:0)
+	// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)
+	// Storage: `System::Account` (r:1 w:1)
+	// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	// Storage: `Vesting::CounterForVestingSchedules` (r:1 w:1)
+	// Proof: `Vesting::CounterForVestingSchedules` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
 	fn bridge_all_vesting_schedules() -> Weight {
-		// Minimum execution time: 133_520 nanoseconds.
-		Weight::from_parts(137_240_000_u64, 0)
-			.saturating_add(T::DbWeight::get().reads(8_u64))
-			.saturating_add(T::DbWeight::get().writes(5_u64))
+		// Minimum execution time: 75_000 nanoseconds.
+		Weight::from_parts(78_000_000_u64, 0)
+			.saturating_add(T::DbWeight::get().reads(6_u64))
+			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
 	// Storage: `Vesting::Renounced` (r:0 w:1)
 	// Proof: `Vesting::Renounced` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)
@@ -173,11 +184,23 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(8_u64))
 			.saturating_add(RocksDbWeight::get().writes(5_u64))
 	}
-	// TODO redo benchmarking
+	// Storage: `ParachainSystem::ValidationData` (r:1 w:0)
+	// Proof: `ParachainSystem::ValidationData` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	// Storage: `Vesting::VestingSchedules` (r:1 w:1)
+	// Proof: `Vesting::VestingSchedules` (`max_values`: None, `max_size`: Some(2850), added: 5325, mode: `MaxEncodedLen`)
+	// Storage: `Balances::Locks` (r:1 w:1)
+	// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	// Storage: `Balances::Freezes` (r:1 w:0)
+	// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)
+	// Storage: `System::Account` (r:1 w:1)
+	// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	// Storage: `Vesting::CounterForVestingSchedules` (r:1 w:1)
+	// Proof: `Vesting::CounterForVestingSchedules` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
 	fn bridge_all_vesting_schedules() -> Weight {
-		Weight::from_parts(137_240_000_u64, 0)
-			.saturating_add(RocksDbWeight::get().reads(8_u64))
-			.saturating_add(RocksDbWeight::get().writes(5_u64))
+		// Minimum execution time: 75_000 nanoseconds.
+		Weight::from_parts(78_000_000_u64, 0)
+			.saturating_add(RocksDbWeight::get().reads(6_u64))
+			.saturating_add(RocksDbWeight::get().writes(4_u64))
 	}
 	// Storage: `Vesting::Renounced` (r:0 w:1)
 	// Proof: `Vesting::Renounced` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)

--- a/pallets/grants/src/weights.rs
+++ b/pallets/grants/src/weights.rs
@@ -47,6 +47,8 @@ pub trait WeightInfo {
 	fn claim() -> Weight;
 	fn cancel_all_vesting_schedules() -> Weight;
 	fn bridge_all_vesting_schedules() -> Weight;
+	fn set_bridge() -> Weight;
+	fn remove_bridge() -> Weight;
 	fn renounce() -> Weight;
 }
 
@@ -122,6 +124,22 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_parts(78_000_000_u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
+	}
+	// Storage: `Vesting::Bridges` (r:1 w:1)
+	// Proof: `Vesting::Bridges` (`max_values`: None, `max_size`: Some(61), added: 2536, mode: `MaxEncodedLen`)
+	fn set_bridge() -> Weight {
+		// Minimum execution time: 7_000 nanoseconds.
+		Weight::from_parts(7_000_000_u64, 0)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+	// Storage: `Vesting::Bridges` (r:1 w:1)
+	// Proof: `Vesting::Bridges` (`max_values`: None, `max_size`: Some(61), added: 2536, mode: `MaxEncodedLen`)
+	fn remove_bridge() -> Weight {
+		// Minimum execution time: 8_000 nanoseconds.
+		Weight::from_parts(9_000_000_u64, 0)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 	// Storage: `Vesting::Renounced` (r:0 w:1)
 	// Proof: `Vesting::Renounced` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)
@@ -201,6 +219,22 @@ impl WeightInfo for () {
 		Weight::from_parts(78_000_000_u64, 0)
 			.saturating_add(RocksDbWeight::get().reads(6_u64))
 			.saturating_add(RocksDbWeight::get().writes(4_u64))
+	}
+	// Storage: `Vesting::Bridges` (r:1 w:1)
+	// Proof: `Vesting::Bridges` (`max_values`: None, `max_size`: Some(61), added: 2536, mode: `MaxEncodedLen`)
+	fn set_bridge() -> Weight {
+		// Minimum execution time: 7_000 nanoseconds.
+		Weight::from_parts(7_000_000_u64, 0)
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	// Storage: `Vesting::Bridges` (r:1 w:1)
+	// Proof: `Vesting::Bridges` (`max_values`: None, `max_size`: Some(61), added: 2536, mode: `MaxEncodedLen`)
+	fn remove_bridge() -> Weight {
+		// Minimum execution time: 8_000 nanoseconds.
+		Weight::from_parts(9_000_000_u64, 0)
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
 	// Storage: `Vesting::Renounced` (r:0 w:1)
 	// Proof: `Vesting::Renounced` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)

--- a/pallets/grants/src/weights.rs
+++ b/pallets/grants/src/weights.rs
@@ -46,6 +46,7 @@ pub trait WeightInfo {
 	fn add_vesting_schedule() -> Weight;
 	fn claim() -> Weight;
 	fn cancel_all_vesting_schedules() -> Weight;
+	fn bridge_all_vesting_schedules() -> Weight;
 	fn renounce() -> Weight;
 }
 
@@ -99,6 +100,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: `Vesting::CounterForVestingSchedules` (r:1 w:1)
 	// Proof: `Vesting::CounterForVestingSchedules` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
 	fn cancel_all_vesting_schedules() -> Weight {
+		// Minimum execution time: 133_520 nanoseconds.
+		Weight::from_parts(137_240_000_u64, 0)
+			.saturating_add(T::DbWeight::get().reads(8_u64))
+			.saturating_add(T::DbWeight::get().writes(5_u64))
+	}
+	// TODO redo benchmarking
+	fn bridge_all_vesting_schedules() -> Weight {
 		// Minimum execution time: 133_520 nanoseconds.
 		Weight::from_parts(137_240_000_u64, 0)
 			.saturating_add(T::DbWeight::get().reads(8_u64))
@@ -161,6 +169,12 @@ impl WeightInfo for () {
 	// Proof: `Vesting::CounterForVestingSchedules` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
 	fn cancel_all_vesting_schedules() -> Weight {
 		// Minimum execution time: 133_520 nanoseconds.
+		Weight::from_parts(137_240_000_u64, 0)
+			.saturating_add(RocksDbWeight::get().reads(8_u64))
+			.saturating_add(RocksDbWeight::get().writes(5_u64))
+	}
+	// TODO redo benchmarking
+	fn bridge_all_vesting_schedules() -> Weight {
 		Weight::from_parts(137_240_000_u64, 0)
 			.saturating_add(RocksDbWeight::get().reads(8_u64))
 			.saturating_add(RocksDbWeight::get().writes(5_u64))

--- a/runtimes/eden/src/weights/pallet_grants.rs
+++ b/runtimes/eden/src/weights/pallet_grants.rs
@@ -98,6 +98,13 @@ impl<T: frame_system::Config> pallet_grants::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(8_u64))
 			.saturating_add(T::DbWeight::get().writes(5_u64))
 	}
+	// TODO redo benchmark
+	fn bridge_all_vesting_schedules() -> Weight {
+		// Minimum execution time: 143_329 nanoseconds.
+		Weight::from_parts(144_750_000_u64, 0)
+			.saturating_add(T::DbWeight::get().reads(8_u64))
+			.saturating_add(T::DbWeight::get().writes(5_u64))
+	}
 	// Storage: `Vesting::Renounced` (r:0 w:1)
 	// Proof: `Vesting::Renounced` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)
 	fn renounce() -> Weight {

--- a/runtimes/eden/src/weights/pallet_grants.rs
+++ b/runtimes/eden/src/weights/pallet_grants.rs
@@ -116,6 +116,22 @@ impl<T: frame_system::Config> pallet_grants::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(6_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
+		// Storage: `Vesting::Bridges` (r:1 w:1)
+	// Proof: `Vesting::Bridges` (`max_values`: None, `max_size`: Some(61), added: 2536, mode: `MaxEncodedLen`)
+	fn set_bridge() -> Weight {
+		// Minimum execution time: 7_000 nanoseconds.
+		Weight::from_parts(7_000_000_u64, 0)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+	// Storage: `Vesting::Bridges` (r:1 w:1)
+	// Proof: `Vesting::Bridges` (`max_values`: None, `max_size`: Some(61), added: 2536, mode: `MaxEncodedLen`)
+	fn remove_bridge() -> Weight {
+		// Minimum execution time: 8_000 nanoseconds.
+		Weight::from_parts(9_000_000_u64, 0)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
 	// Storage: `Vesting::Renounced` (r:0 w:1)
 	// Proof: `Vesting::Renounced` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)
 	fn renounce() -> Weight {

--- a/runtimes/eden/src/weights/pallet_grants.rs
+++ b/runtimes/eden/src/weights/pallet_grants.rs
@@ -98,12 +98,23 @@ impl<T: frame_system::Config> pallet_grants::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(8_u64))
 			.saturating_add(T::DbWeight::get().writes(5_u64))
 	}
-	// TODO redo benchmark
+	// Storage: `ParachainSystem::ValidationData` (r:1 w:0)
+	// Proof: `ParachainSystem::ValidationData` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	// Storage: `Vesting::VestingSchedules` (r:1 w:1)
+	// Proof: `Vesting::VestingSchedules` (`max_values`: None, `max_size`: Some(2850), added: 5325, mode: `MaxEncodedLen`)
+	// Storage: `Balances::Locks` (r:1 w:1)
+	// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	// Storage: `Balances::Freezes` (r:1 w:0)
+	// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)
+	// Storage: `System::Account` (r:1 w:1)
+	// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	// Storage: `Vesting::CounterForVestingSchedules` (r:1 w:1)
+	// Proof: `Vesting::CounterForVestingSchedules` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
 	fn bridge_all_vesting_schedules() -> Weight {
-		// Minimum execution time: 143_329 nanoseconds.
-		Weight::from_parts(144_750_000_u64, 0)
-			.saturating_add(T::DbWeight::get().reads(8_u64))
-			.saturating_add(T::DbWeight::get().writes(5_u64))
+		// Minimum execution time: 75_000 nanoseconds.
+		Weight::from_parts(78_000_000_u64, 0)
+			.saturating_add(T::DbWeight::get().reads(6_u64))
+			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
 	// Storage: `Vesting::Renounced` (r:0 w:1)
 	// Proof: `Vesting::Renounced` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)


### PR DESCRIPTION
1. The bridge is initiated by the user/grant owner similar to how bridging of free tokens currently happening.
2. The bridge_all_vesting_schedules function is added to to pallet-grants which will be very similar to cancel_all_vesting_schedules with the difference that for this one only the owner of the grant and not the governance of the chain can initiate a bridge for locked tokens.
3. Similar to cancel_… bridge_all_vesting_schedules  will first do a claim for the user so they get all their free-able tokens into their own account first.
4. bridge_all_vesting_schedules burns the locked grants of the user and remove their details as well if it succeeds.
5. bridge_all_vesting_schedules will then generate an event traceable by our bridge off-chain oracles which indicates a bridge operation is complete on the parachain side with the user’s given zksync address as the destination.

- [x] Add benchmark test
- [x] Do an initial benchmark